### PR TITLE
feat: add maximum buy percentage

### DIFF
--- a/contracts/src/tokens/interface.cairo
+++ b/contracts/src/tokens/interface.cairo
@@ -62,5 +62,4 @@ trait IUnruggableMemecoinSnake<TState> {
 #[starknet::interface]
 trait IUnruggableAdditional<TState> {
     fn launch_memecoin(ref self: TState);
-    fn get_max_buy_percentage(self: @TState) -> u256;
 }

--- a/contracts/src/tokens/interface.cairo
+++ b/contracts/src/tokens/interface.cairo
@@ -62,4 +62,5 @@ trait IUnruggableMemecoinSnake<TState> {
 #[starknet::interface]
 trait IUnruggableAdditional<TState> {
     fn launch_memecoin(ref self: TState);
+    fn get_max_buy_percentage(self: @TState) -> u256;
 }

--- a/contracts/src/tokens/memecoin.cairo
+++ b/contracts/src/tokens/memecoin.cairo
@@ -120,6 +120,7 @@ mod UnruggableMemecoin {
         }
 
         fn transfer(ref self: ContractState, recipient: ContractAddress, amount: u256) -> bool {
+            self._check_max_buy_percentage(amount);
             let sender = get_caller_address();
             self._transfer(sender, recipient, amount);
             true
@@ -132,6 +133,7 @@ mod UnruggableMemecoin {
             amount: u256
         ) -> bool {
             let caller = get_caller_address();
+            self._check_max_buy_percentage(amount);
             self.erc20._spend_allowance(sender, caller, amount);
             self.erc20._transfer(sender, recipient, amount);
             true
@@ -178,6 +180,15 @@ mod UnruggableMemecoin {
             amount: u256
         ) {
             self.erc20._transfer(sender, recipient, amount);
+        }
+
+        fn _check_max_buy_percentage(self: @ContractState, amount: u256) {
+            assert(
+                self.erc20.ERC20_total_supply.read()
+                    * MAX_PERCENTAGE_BUY_LAUNCH.into()
+                    / 100 >= amount,
+                'Max buy cap reached'
+            )
         }
     }
 }

--- a/contracts/src/tokens/memecoin.cairo
+++ b/contracts/src/tokens/memecoin.cairo
@@ -98,12 +98,6 @@ mod UnruggableMemecoin {
 
         // Interactions.
         }
-         fn get_max_buy_percentage(self: @ContractState) -> u256 {
-             self.erc20.ERC20_total_supply.read()
-                    * MAX_PERCENTAGE_BUY_LAUNCH.into()
-                    / 100
-        }
-        
     }
 
     #[abi(embed_v0)]
@@ -190,7 +184,9 @@ mod UnruggableMemecoin {
 
         fn _check_max_buy_percentage(self: @ContractState, amount: u256) {
             assert(
-                self.get_max_buy_percentage() >= amount,
+                self.erc20.ERC20_total_supply.read()
+                    * MAX_PERCENTAGE_BUY_LAUNCH.into()
+                    / 100 >= amount,
                 'Max buy cap reached'
             )
         }

--- a/contracts/src/tokens/memecoin.cairo
+++ b/contracts/src/tokens/memecoin.cairo
@@ -98,6 +98,9 @@ mod UnruggableMemecoin {
 
         // Interactions.
         }
+        fn get_max_buy_percentage(self: @ContractState) -> u256 {
+            self.erc20.ERC20_total_supply.read() * MAX_PERCENTAGE_BUY_LAUNCH.into() / 100
+        }
     }
 
     #[abi(embed_v0)]

--- a/contracts/src/tokens/memecoin.cairo
+++ b/contracts/src/tokens/memecoin.cairo
@@ -98,6 +98,12 @@ mod UnruggableMemecoin {
 
         // Interactions.
         }
+         fn get_max_buy_percentage(self: @ContractState) -> u256 {
+             self.erc20.ERC20_total_supply.read()
+                    * MAX_PERCENTAGE_BUY_LAUNCH.into()
+                    / 100
+        }
+        
     }
 
     #[abi(embed_v0)]
@@ -184,9 +190,7 @@ mod UnruggableMemecoin {
 
         fn _check_max_buy_percentage(self: @ContractState, amount: u256) {
             assert(
-                self.erc20.ERC20_total_supply.read()
-                    * MAX_PERCENTAGE_BUY_LAUNCH.into()
-                    / 100 >= amount,
+                self.get_max_buy_percentage() >= amount,
                 'Max buy cap reached'
             )
         }

--- a/contracts/tests/test_unruggable_memecoin.cairo
+++ b/contracts/tests/test_unruggable_memecoin.cairo
@@ -374,4 +374,25 @@ mod memecoin_entrypoints {
         let send_amount = memecoin.transfer_from(owner,alice, 500);
         assert(memecoin.balance_of(alice) == 500.into(), 'Invalid balance');
     }
+
+    #[test]
+    fn test_classic_max_percentage() {
+        let owner = contract_address_const::<42>();
+        let alice = contract_address_const::<53>();
+        let initial_supply = 1000.into();
+        let contract_address = deploy_contract(
+            owner, owner, 'UnruggableMemecoin', 'MT', initial_supply
+        );
+
+        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
+
+        // Check initial balance. Should be equal to initial supply.
+        let balance = memecoin.balance_of(owner);
+        assert(balance == initial_supply, 'Invalid balance');
+
+        // Transfer 1 token from owner to alice.
+        start_prank(CheatTarget::One(memecoin.contract_address), owner);
+        let send_amount = memecoin.transfer(alice, 100);
+        assert(memecoin.balance_of(alice) == 100.into(), 'Invalid balance');
+    }
 }

--- a/contracts/tests/test_unruggable_memecoin.cairo
+++ b/contracts/tests/test_unruggable_memecoin.cairo
@@ -171,15 +171,15 @@ mod erc20_entrypoints {
 
         // Transfer 100 tokens to recipient.
         start_prank(CheatTarget::One(memecoin.contract_address), owner);
-        memecoin.transfer(recipient, 100.into());
+        memecoin.transfer(recipient, 10.into());
 
         // Check balance. Should be equal to initial supply - 100.
         let owner_balance = memecoin.balance_of(owner);
-        assert(owner_balance == (initial_supply - 100.into()), 'Invalid balance owner');
+        assert(owner_balance == (initial_supply - 10.into()), 'Invalid balance owner');
 
         // Check recipient balance. Should be equal to 100.
         let recipient_balance = memecoin.balance_of(recipient);
-        assert(recipient_balance == 100.into(), 'Invalid balance recipient');
+        assert(recipient_balance == 10.into(), 'Invalid balance recipient');
     }
 
     #[test]
@@ -204,19 +204,19 @@ mod erc20_entrypoints {
 
         // Transfer 100 tokens to recipient.
         start_prank(CheatTarget::One(memecoin.contract_address), spender);
-        memecoin.transfer_from(owner, recipient, 100.into());
+        memecoin.transfer_from(owner, recipient, 10.into());
 
         // Check balance. Should be equal to initial supply - 100.
         let owner_balance = memecoin.balance_of(owner);
-        assert(owner_balance == (initial_supply - 100.into()), 'Invalid balance owner');
+        assert(owner_balance == (initial_supply - 10.into()), 'Invalid balance owner');
 
         // Check recipient balance. Should be equal to 100.
         let recipient_balance = memecoin.balance_of(recipient);
-        assert(recipient_balance == 100.into(), 'Invalid balance recipient');
+        assert(recipient_balance == 10.into(), 'Invalid balance recipient');
 
         // Check allowance. Should be equal to initial supply - 100.
         let allowance = memecoin.allowance(owner, spender);
-        assert(allowance == (initial_supply - 100.into()), 'Invalid allowance');
+        assert(allowance == (initial_supply - 10.into()), 'Invalid allowance');
     }
 
     // Test ERC20 Camel entrypoints

--- a/contracts/tests/test_unruggable_memecoin.cairo
+++ b/contracts/tests/test_unruggable_memecoin.cairo
@@ -329,4 +329,49 @@ mod memecoin_entrypoints {
 
         memecoin.launch_memecoin();
     }
+
+    #[test]
+    #[should_panic(expected: ('Max buy cap reached',))]
+    fn test_transfer_max_percentage() {
+        let owner = contract_address_const::<42>();
+        let alice = contract_address_const::<53>();
+        let initial_supply = 1000.into();
+        let contract_address = deploy_contract(
+            owner, owner, 'UnruggableMemecoin', 'MT', initial_supply
+        );
+
+        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
+
+        // Check initial balance. Should be equal to initial supply.
+        let balance = memecoin.balance_of(owner);
+        assert(balance == initial_supply, 'Invalid balance');
+
+        // Transfer 1 token from owner to alice.
+        start_prank(CheatTarget::One(memecoin.contract_address), owner);
+        let send_amount = memecoin.transfer(alice, 500);
+        assert(memecoin.balance_of(alice) == 500.into(), 'Invalid balance');
+    }
+
+
+    #[test]
+    #[should_panic(expected: ('Max buy cap reached',))]
+    fn test_transfer_from_max_percentage() {
+        let owner = contract_address_const::<42>();
+        let alice = contract_address_const::<53>();
+        let initial_supply = 1000.into();
+        let contract_address = deploy_contract(
+            owner, owner, 'UnruggableMemecoin', 'MT', initial_supply
+        );
+
+        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
+
+        // Check initial balance. Should be equal to initial supply.
+        let balance = memecoin.balance_of(owner);
+        assert(balance == initial_supply, 'Invalid balance');
+
+        // Transfer 1 token from owner to alice.
+        start_prank(CheatTarget::One(memecoin.contract_address), owner);
+        let send_amount = memecoin.transfer_from(owner,alice, 500);
+        assert(memecoin.balance_of(alice) == 500.into(), 'Invalid balance');
+    }
 }

--- a/contracts/tests/test_unruggable_memecoin.cairo
+++ b/contracts/tests/test_unruggable_memecoin.cairo
@@ -291,6 +291,7 @@ mod erc20_entrypoints {
 
 mod memecoin_entrypoints {
     use core::debug::PrintTrait;
+    use core::traits::Into;
     use openzeppelin::token::erc20::interface::IERC20;
     use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank, CheatTarget};
     use starknet::{ContractAddress, contract_address_const};
@@ -371,7 +372,7 @@ mod memecoin_entrypoints {
 
         // Transfer 1 token from owner to alice.
         start_prank(CheatTarget::One(memecoin.contract_address), owner);
-        let send_amount = memecoin.transfer_from(owner,alice, 500);
+        let send_amount = memecoin.transfer_from(owner, alice, 500);
         assert(memecoin.balance_of(alice) == 500.into(), 'Invalid balance');
     }
 
@@ -392,7 +393,7 @@ mod memecoin_entrypoints {
 
         // Transfer 1 token from owner to alice.
         start_prank(CheatTarget::One(memecoin.contract_address), owner);
-        let send_amount = memecoin.transfer(alice, 100);
-        assert(memecoin.balance_of(alice) == 100.into(), 'Invalid balance');
+        let send_amount = memecoin.transfer(alice, 10.into());
+        assert(memecoin.balance_of(alice) == 10.into(), 'Invalid balance');
     }
 }


### PR DESCRIPTION
implement check maximum buy percentage #6


```js
   fn check_max_buy_percentage(self: @ContractState, amount: u256)
```

Test function

```js
test_transfer_max_percentage()

test_transfer_from_max_percentage()
```

We need the launch phase logic to check the max percentage only during the launch duration

Suggestion: 

Add a set_max_percentage function for custom setting