### PR TITLE
redesign initial distribution logic

### DIFF
--- a/contracts/src/tokens/memecoin.cairo
+++ b/contracts/src/tokens/memecoin.cairo
@@ -3,12 +3,16 @@ use starknet::ContractAddress;
 
 #[starknet::contract]
 mod UnruggableMemecoin {
-    use core::array::ArrayTrait;
+    use array::ArrayTrait;
     use integer::BoundedInt;
     use openzeppelin::access::ownable::OwnableComponent;
-    use openzeppelin::access::ownable::ownable::OwnableComponent::InternalTrait;
+    use openzeppelin::access::ownable::ownable::OwnableComponent::InternalTrait as OwnableInternalTrait;
     use openzeppelin::token::erc20::ERC20Component;
-    use starknet::{ContractAddress, get_caller_address};
+    use option::OptionTrait;
+    use starknet::{
+        ContractAddress, contract_address_const, get_contract_address, get_caller_address
+    };
+    use traits::TryInto;
     use unruggable::tokens::interface::{
         IUnruggableMemecoinSnake, IUnruggableMemecoinCamel, IUnruggableAdditional
     };
@@ -33,15 +37,16 @@ mod UnruggableMemecoin {
     const MAX_HOLDERS_BEFORE_LAUNCH: u8 = 10;
     /// The maximum percentage of the total supply that can be allocated to the team.
     /// This is to prevent the team from having too much control over the supply.
-    const MAX_SUPPLY_PERCENTAGE_TEAM_ALLOCATION: u8 = 10;
+    const MAX_SUPPLY_PERCENTAGE_TEAM_ALLOCATION: u16 = 1_000; // 10%
     /// The maximum percentage of the supply that can be bought at once.
-    const MAX_PERCENTAGE_BUY_LAUNCH: u8 = 2;
+    const MAX_PERCENTAGE_BUY_LAUNCH: u8 = 200; // 2%
 
     #[storage]
     struct Storage {
         marker_v_0: (),
         launched: bool,
         pre_launch_holders_count: u8,
+        team_allocation: u256,
         // Components.
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
@@ -61,6 +66,7 @@ mod UnruggableMemecoin {
     mod Errors {
         const MAX_HOLDERS_REACHED: felt252 = 'Unruggable: max holders reached';
         const ARRAYS_LEN_DIF: felt252 = 'Unruggable: arrays len dif';
+        const MAX_TEAM_ALLOCATION_REACHED: felt252 = 'Unruggable: max team allocation';
     }
 
 
@@ -72,12 +78,11 @@ mod UnruggableMemecoin {
     /// * `symbol` - The symbol of the token.
     /// * `initial_supply` - The initial supply of the token.
     /// * `initial_holders` - The initial holders of the token, an array of holder_address
-    /// * `initial_holders_amounts` - The initial amounts of tokens minted to the initial holders, an array of amounts   
+    /// * `initial_holders_amounts` - The initial amounts of tokens minted to the initial holders, an array of amounts
     #[constructor]
     fn constructor(
         ref self: ContractState,
         owner: ContractAddress,
-        initial_recipient: ContractAddress,
         name: felt252,
         symbol: felt252,
         initial_supply: u256,
@@ -90,22 +95,8 @@ mod UnruggableMemecoin {
         // Initialize the owner.
         self.ownable.initializer(owner);
 
-        assert(initial_holders.len() == initial_holders_amounts.len(), Errors::ARRAYS_LEN_DIF);
-        assert(
-            initial_holders.len() <= MAX_HOLDERS_BEFORE_LAUNCH.into(), Errors::MAX_HOLDERS_REACHED
-        );
-
         // Initialize the token / internal logic
-        self
-            ._initializer(
-                owner,
-                initial_recipient,
-                name,
-                symbol,
-                initial_supply,
-                initial_holders,
-                initial_holders_amounts
-            );
+        self._initializer(:initial_supply, :initial_holders, :initial_holders_amounts);
     }
 
     //
@@ -133,9 +124,7 @@ mod UnruggableMemecoin {
 
         /// Returns the team allocation in tokens.
         fn get_team_allocation(self: @ContractState) -> u256 {
-            self.erc20.ERC20_total_supply.read()
-                * MAX_SUPPLY_PERCENTAGE_TEAM_ALLOCATION.into()
-                / 100
+            self.team_allocation.read()
         }
     }
 
@@ -216,16 +205,32 @@ mod UnruggableMemecoin {
         ///
         /// Note that when transfers are done, between addresses that already
         /// hold tokens, we do not increment the number of holders. it only
-        /// gets incremented when the recipient that hold no tokens
+        /// gets incremented when the recipient that hold no tokens.
+        /// But if the sender will no longer hold tokens after the transfer,
+        /// the number of holders is decremented.
         ///
         /// # Arguments
+        /// * `sender` - The sender of the tokens being transferred.
         /// * `recipient` - The recipient of the tokens being transferred.
+        /// * `amount` - The amount of tokens being transferred.
         #[inline(always)]
-        fn _enforce_holders_limit(ref self: ContractState, recipient: ContractAddress) {
+        fn _enforce_holders_limit(
+            ref self: ContractState,
+            sender: ContractAddress,
+            recipient: ContractAddress,
+            amount: u256
+        ) {
             // enforce max number of holders before launch
 
-            if !self.launched.read() && self.balance_of(recipient) == 0 {
-                let current_holders_count = self.pre_launch_holders_count.read();
+            let current_holders_count = self.pre_launch_holders_count.read();
+
+            // if the sender will no longer hold tokens
+            if sender.is_non_zero() && self.balance_of(sender) == amount {
+                self.pre_launch_holders_count.write(current_holders_count - 1);
+            }
+
+            // if the recipient doesn't hold tokens yet
+            if !self.launched.read() && self.balance_of(recipient).is_zero() {
                 assert(
                     current_holders_count < MAX_HOLDERS_BEFORE_LAUNCH, Errors::MAX_HOLDERS_REACHED
                 );
@@ -234,26 +239,25 @@ mod UnruggableMemecoin {
             }
         }
 
-
         /// Internal function to mint tokens
         ///
-        /// Before minting, a check is done to ensure that 
-        /// only `MAX_HOLDERS_BEFORE_LAUNCH` addresses can hold 
-        /// tokens if token hasn't launched 
+        /// Before minting, a check is done to ensure that
+        /// only `MAX_HOLDERS_BEFORE_LAUNCH` addresses can hold
+        /// tokens if token hasn't launched
         ///
         /// # Arguments
         /// * `recipient` - The recipient of the tokens.
         /// * `amount` - The amount of tokens to be minted.
         fn _mint(ref self: ContractState, recipient: ContractAddress, amount: u256) {
-            self._enforce_holders_limit(recipient);
+            self._enforce_holders_limit(sender: contract_address_const::<0>(), :recipient, :amount);
             self.erc20._mint(recipient, amount);
         }
 
         /// Internal function to transfer tokens
         ///
-        /// Before transferring, a check is done to ensure that 
-        /// only `MAX_HOLDERS_BEFORE_LAUNCH` addresses can hold 
-        /// tokens if token hasn't launched 
+        /// Before transferring, a check is done to ensure that
+        /// only `MAX_HOLDERS_BEFORE_LAUNCH` addresses can hold
+        /// tokens if token hasn't launched
         ///
         /// # Arguments
         /// * `sender` - The sender or owner of the tokens.
@@ -265,65 +269,84 @@ mod UnruggableMemecoin {
             recipient: ContractAddress,
             amount: u256
         ) {
-            self._enforce_holders_limit(recipient);
+            self._enforce_holders_limit(:sender, :recipient, :amount);
             self.erc20._transfer(sender, recipient, amount);
         }
 
+        /// Internal function to assert the buy limit is not reached
+        ///
+        /// This check ensure that an address cannot buy more
+        /// than the maximum percentage of the supply that can
+        /// be bought at once.
+        ///
+        /// # Arguments
+        /// * `amount` - The amount of tokens being transferred.
+        #[inline(always)]
         fn _check_max_buy_percentage(self: @ContractState, amount: u256) {
             assert(
                 self.erc20.ERC20_total_supply.read()
                     * MAX_PERCENTAGE_BUY_LAUNCH.into()
-                    / 100 >= amount,
+                    / 10_000 >= amount,
                 'Max buy cap reached'
             )
         }
 
         /// Constructor logic.
         /// # Arguments
-        /// * `owner` - The owner of the contract.
-        /// * `owner` - The owner of the contract.
-        /// * `initial_recipient` - The initial recipient of the initial supply.
-        /// * `name` - The name of the token.
-        /// * `symbol` - The symbol of the token.
         /// * `initial_supply` - The initial supply of the token.
         /// * `initial_holders` - The initial holders of the token, an array of holder_address
-        /// * `initial_holders_amounts` - The initial amounts of tokens minted to the initial holders, an array of amounts        
+        /// * `initial_holders_amounts` - The initial amounts of tokens minted to the initial holders, an array of amounts
         fn _initializer(
             ref self: ContractState,
-            owner: ContractAddress,
-            initial_recipient: ContractAddress,
-            name: felt252,
-            symbol: felt252,
             initial_supply: u256,
             initial_holders: Span<ContractAddress>,
             initial_holders_amounts: Span<u256>
         ) {
-            let mut initial_minted_supply: u256 = 0;
             let mut team_allocation: u256 = 0;
+            let max_team_allocation = initial_supply
+                * MAX_SUPPLY_PERCENTAGE_TEAM_ALLOCATION.into()
+                / 10_000;
             let mut i: usize = 0;
+
+            // check initial holders len match
+            assert(initial_holders.len() == initial_holders_amounts.len(), Errors::ARRAYS_LEN_DIF);
+
+            // check on max holders count
+            assert(
+                initial_holders.len() <= MAX_HOLDERS_BEFORE_LAUNCH.into(),
+                Errors::MAX_HOLDERS_REACHED
+            );
+
             loop {
                 if i >= initial_holders.len() {
                     break;
                 }
+
                 let address = *initial_holders.at(i);
                 let amount = *initial_holders_amounts.at(i);
-                initial_minted_supply += amount;
-                if (i == 0) {
-                    assert(address == initial_recipient, 'initial recipient mismatch');
-                    // NO HOLDING LIMIT HERE. IT IS THE ACCOUNT THAT WILL LAUNCH THE LIQUIDITY POOL
-                    self.erc20._mint(address, amount);
-                } else {
-                    team_allocation += amount;
-                    let max_alloc = initial_supply
-                        * MAX_SUPPLY_PERCENTAGE_TEAM_ALLOCATION.into()
-                        / 100;
-                    assert(team_allocation <= max_alloc, 'Unruggable: max team allocation');
-                    self.erc20._mint(address, amount);
-                }
-                self.pre_launch_holders_count.write(self.pre_launch_holders_count.read() + 1);
+
+                // increase team allocation
+                team_allocation += amount;
+
+                // check on max team allocation
+                assert(team_allocation <= max_team_allocation, Errors::MAX_TEAM_ALLOCATION_REACHED);
+
+                // mint to holder using the erc20 internal to avoid triggering pre launch safeguards and waste gas.
+                self.erc20._mint(recipient: address, :amount);
+
                 i += 1;
             };
-            assert(initial_minted_supply <= initial_supply, 'Unruggable: max supply reached');
+
+            // mint remaining supply to the contract
+            self
+                .erc20
+                ._mint(recipient: get_contract_address(), amount: initial_supply - team_allocation);
+
+            // save team allocation
+            self.team_allocation.write(team_allocation);
+
+            // save pre launch holders count
+            self.pre_launch_holders_count.write(initial_holders.len().try_into().unwrap());
         }
     }
 }

--- a/contracts/tests/test_unruggable_memecoin.cairo
+++ b/contracts/tests/test_unruggable_memecoin.cairo
@@ -11,9 +11,24 @@ use unruggable::tokens::interface::{
     IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
 };
 
+//
+// Constants
+//
+
+fn RECIPIENT() -> ContractAddress {
+    return contract_address_const::<'RECIPIENT'>();
+}
+
+fn SPENDER() -> ContractAddress {
+    return contract_address_const::<'RECIPIENT'>();
+}
+
+//
+// Setup
+//
+
 fn deploy_contract(
     owner: ContractAddress,
-    recipient: ContractAddress,
     name: felt252,
     symbol: felt252,
     initial_supply: u256,
@@ -22,12 +37,7 @@ fn deploy_contract(
 ) -> Result<ContractAddress, RevertedTransaction> {
     let contract = declare('UnruggableMemecoin');
     let mut constructor_calldata = array![
-        owner.into(),
-        recipient.into(),
-        name,
-        symbol,
-        initial_supply.low.into(),
-        initial_supply.high.into()
+        owner.into(), name, symbol, initial_supply.low.into(), initial_supply.high.into()
     ];
     Serde::serialize(@initial_holders.into(), ref constructor_calldata);
     Serde::serialize(@initial_holders_amounts.into(), ref constructor_calldata);
@@ -35,7 +45,6 @@ fn deploy_contract(
 }
 
 fn instantiate_params() -> (
-    ContractAddress,
     ContractAddress,
     felt252,
     felt252,
@@ -46,17 +55,15 @@ fn instantiate_params() -> (
     Span<u256>,
 ) {
     let owner = contract_address_const::<42>();
-    let recipient = contract_address_const::<43>();
     let name = 'UnruggableMemecoin';
     let symbol = 'UM';
-    let initial_supply = 1000.into();
+    let initial_supply = 1000;
     let initial_holder_1 = contract_address_const::<44>();
     let initial_holder_2 = contract_address_const::<45>();
-    let initial_holders = array![recipient, initial_holder_1, initial_holder_2].span();
-    let initial_holders_amounts = array![900.into(), 50.into(), 50.into()].span();
+    let initial_holders = array![initial_holder_1, initial_holder_2].span();
+    let initial_holders_amounts = array![50, 50].span();
     (
         owner,
-        recipient,
         name,
         symbol,
         initial_supply,
@@ -82,7 +89,6 @@ mod erc20_metadata {
     fn test_name() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -92,17 +98,9 @@ mod erc20_metadata {
             initial_holders_amounts
         ) =
             instantiate_params();
-        // let initial_holders = array![recipient, initial_holder_1, initial_holder_2].span();
-        // let initial_holders_amounts = array![900.into(), 50.into(), 50.into()].span();
         let contract_address =
             match deploy_contract(
-                owner,
-                recipient,
-                name,
-                symbol,
-                initial_supply,
-                initial_holders,
-                initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -119,7 +117,6 @@ mod erc20_metadata {
     fn test_decimals() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -131,13 +128,7 @@ mod erc20_metadata {
             instantiate_params();
         let contract_address =
             match deploy_contract(
-                owner,
-                recipient,
-                name,
-                symbol,
-                initial_supply,
-                initial_holders,
-                initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -149,11 +140,11 @@ mod erc20_metadata {
         let decimals = memecoin.decimals();
         assert(decimals == 18, 'Invalid decimals');
     }
+
     #[test]
     fn test_symbol() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -165,13 +156,7 @@ mod erc20_metadata {
             instantiate_params();
         let contract_address =
             match deploy_contract(
-                owner,
-                recipient,
-                name,
-                symbol,
-                initial_supply,
-                initial_holders,
-                initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -184,6 +169,7 @@ mod erc20_metadata {
     }
 }
 mod erc20_entrypoints {
+    use core::array::SpanTrait;
     use core::debug::PrintTrait;
     use core::traits::Into;
     use openzeppelin::token::erc20::interface::IERC20;
@@ -200,7 +186,6 @@ mod erc20_entrypoints {
     fn test_total_supply() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -212,13 +197,7 @@ mod erc20_entrypoints {
             instantiate_params();
         let contract_address =
             match deploy_contract(
-                owner,
-                recipient,
-                name,
-                symbol,
-                initial_supply,
-                initial_holders,
-                initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -235,7 +214,6 @@ mod erc20_entrypoints {
     fn test_balance_of() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -247,13 +225,7 @@ mod erc20_entrypoints {
             instantiate_params();
         let contract_address =
             match deploy_contract(
-                owner,
-                recipient,
-                name,
-                symbol,
-                initial_supply,
-                initial_holders,
-                initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -261,8 +233,8 @@ mod erc20_entrypoints {
 
         let memecoin = IUnruggableMemecoinDispatcher { contract_address };
 
-        // Check initial recipient balance. Should be equal to 900.
-        let balance = memecoin.balance_of(recipient);
+        // Check initial contract balance. Should be equal to 900.
+        let balance = memecoin.balance_of(contract_address);
         assert(balance == 900, 'Invalid balance');
         // Check initial holder 1 balance. Should be equal to 50.
         let balance = memecoin.balance_of(initial_holder_1);
@@ -276,20 +248,19 @@ mod erc20_entrypoints {
     fn test_approve_allowance() {
         let (
             owner,
-            spender,
             name,
             symbol,
             initial_supply,
             initial_holder_1,
             initial_holder_2,
-            _,
+            initial_holders,
             initial_holders_amounts
         ) =
             instantiate_params();
-        let initial_holders = array![owner, initial_holder_1, initial_holder_2].span();
+        let spender = super::SPENDER();
         let contract_address =
             match deploy_contract(
-                owner, owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -299,7 +270,7 @@ mod erc20_entrypoints {
 
         // Check initial allowance. Should be equal to 0.
         let allowance = memecoin.allowance(owner, spender);
-        assert(allowance == 0.into(), 'Invalid allowance before');
+        assert(allowance == 0, 'Invalid allowance before');
 
         // Approve initial supply tokens.
         start_prank(CheatTarget::One(memecoin.contract_address), owner);
@@ -314,20 +285,19 @@ mod erc20_entrypoints {
     fn test_transfer() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
             initial_holder_1,
             initial_holder_2,
-            _,
+            initial_holders,
             initial_holders_amounts
         ) =
             instantiate_params();
-        let initial_holders = array![owner, initial_holder_1, initial_holder_2].span();
+        let recipient = super::RECIPIENT();
         let contract_address =
             match deploy_contract(
-                owner, owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -335,38 +305,37 @@ mod erc20_entrypoints {
 
         let memecoin = IUnruggableMemecoinDispatcher { contract_address };
 
-        // Transfer 100 tokens to recipient.
-        start_prank(CheatTarget::One(memecoin.contract_address), owner);
-        memecoin.transfer(recipient, 20.into());
+        // Transfer 20 tokens to recipient.
+        start_prank(CheatTarget::One(memecoin.contract_address), initial_holder_1);
+        memecoin.transfer(recipient, 20);
 
-        // Check balance. Should be equal to initial supply - initial distrib (50 each) - 20.
-        let owner_balance = memecoin.balance_of(owner);
-        assert(owner_balance == (900 - 20.into()), 'Invalid balance owner');
+        // Check balance. Should be equal to initial balance - 20.
+        let initial_holder_1_balance = memecoin.balance_of(initial_holder_1);
+        assert(initial_holder_1_balance == 50 - 20, 'Invalid balance holder 1');
 
-        // Check recipient balance. Should be equal to 100.
+        // Check recipient balance. Should be equal to 20.
         let recipient_balance = memecoin.balance_of(recipient);
-        assert(recipient_balance == 20.into(), 'Invalid balance recipient');
+        assert(recipient_balance == 20, 'Invalid balance recipient');
     }
 
     #[test]
     fn test_transfer_from() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
             initial_holder_1,
             initial_holder_2,
-            _,
+            initial_holders,
             initial_holders_amounts
         ) =
             instantiate_params();
-        let spender = contract_address_const::<46>();
-        let initial_holders = array![owner, initial_holder_1, initial_holder_2].span();
+        let spender = super::SPENDER();
+        let recipient = super::RECIPIENT();
         let contract_address =
             match deploy_contract(
-                owner, owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -374,29 +343,29 @@ mod erc20_entrypoints {
 
         let memecoin = IUnruggableMemecoinDispatcher { contract_address };
 
-        // Check initial balance. Should be equal to initial supply - initial distrib of 2*50.
-        let balance = memecoin.balance_of(owner);
-        assert(balance == 900, 'Invalid balance');
+        // Check initial balance. Should be equal to 50.
+        let balance = memecoin.balance_of(initial_holder_1);
+        assert(balance == 50, 'Invalid balance');
 
         // Approve initial supply tokens.
-        start_prank(CheatTarget::One(memecoin.contract_address), owner);
+        start_prank(CheatTarget::One(memecoin.contract_address), initial_holder_1);
         memecoin.approve(spender, initial_supply);
 
-        // Transfer 100 tokens to recipient.
+        // Transfer 20 tokens to recipient.
         start_prank(CheatTarget::One(memecoin.contract_address), spender);
-        memecoin.transfer_from(owner, recipient, 20.into());
+        memecoin.transfer_from(initial_holder_1, recipient, 20);
 
-        // Check balance. Should be equal to initial supply - 100.
-        let owner_balance = memecoin.balance_of(owner);
-        assert(owner_balance == (initial_supply - 2 * 50 - 20.into()), 'Invalid balance owner');
+        // Check balance. Should be equal to initial balance - 20.
+        let initial_holder_1_balance = memecoin.balance_of(initial_holder_1);
+        assert(initial_holder_1_balance == 50 - 20, 'Invalid balance holder 1');
 
-        // Check recipient balance. Should be equal to 100.
+        // Check recipient balance. Should be equal to 20.
         let recipient_balance = memecoin.balance_of(recipient);
-        assert(recipient_balance == 20.into(), 'Invalid balance recipient');
+        assert(recipient_balance == 20, 'Invalid balance recipient');
 
         // Check allowance. Should be equal to initial supply - transfered amount.
-        let allowance = memecoin.allowance(owner, spender);
-        assert(allowance == (initial_supply - 20.into()), 'Invalid allowance');
+        let allowance = memecoin.allowance(initial_holder_1, spender);
+        assert(allowance == (initial_supply - 20), 'Invalid allowance');
     }
 
     // Test ERC20 Camel entrypoints
@@ -405,7 +374,6 @@ mod erc20_entrypoints {
     fn test_totalSupply() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -417,13 +385,7 @@ mod erc20_entrypoints {
             instantiate_params();
         let contract_address =
             match deploy_contract(
-                owner,
-                recipient,
-                name,
-                symbol,
-                initial_supply,
-                initial_holders,
-                initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -435,24 +397,23 @@ mod erc20_entrypoints {
         let total_supply = memecoin.totalSupply();
         assert(total_supply == initial_supply, 'Invalid total supply');
     }
+
     #[test]
     fn test_balanceOf() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
             initial_holder_1,
             initial_holder_2,
-            _,
+            initial_holders,
             initial_holders_amounts
         ) =
             instantiate_params();
-        let initial_holders = array![owner, initial_holder_1, initial_holder_2].span();
         let contract_address =
             match deploy_contract(
-                owner, owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -460,8 +421,8 @@ mod erc20_entrypoints {
 
         let memecoin = IUnruggableMemecoinDispatcher { contract_address };
 
-        // Check initial recipient balance. Should be equal to 900.
-        let balance = memecoin.balanceOf(owner);
+        // Check initial contract balance. Should be equal to 900.
+        let balance = memecoin.balanceOf(contract_address);
         assert(balance == 900, 'Invalid balance');
         // Check initial holder 1 balance. Should be equal to 50.
         let balance = memecoin.balanceOf(initial_holder_1);
@@ -470,25 +431,25 @@ mod erc20_entrypoints {
         let balance = memecoin.balanceOf(initial_holder_1);
         assert(balance == 50, 'Invalid balance');
     }
+
     #[test]
     fn test_transferFrom() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
             initial_holder_1,
             initial_holder_2,
-            _,
+            initial_holders,
             initial_holders_amounts
         ) =
             instantiate_params();
-        let initial_holders = array![owner, initial_holder_1, initial_holder_2].span();
-        let spender = contract_address_const::<46>();
+        let spender = super::SPENDER();
+        let recipient = super::RECIPIENT();
         let contract_address =
             match deploy_contract(
-                owner, owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -496,29 +457,29 @@ mod erc20_entrypoints {
 
         let memecoin = IUnruggableMemecoinDispatcher { contract_address };
 
-        // Check initial balance. Should be equal to initial supply.
-        let balance = memecoin.balanceOf(owner);
-        assert(balance == (initial_supply - 2 * 50), 'Invalid balance');
+        // Check initial balance. Should be equal to 50.
+        let balance = memecoin.balance_of(initial_holder_1);
+        assert(balance == 50, 'Invalid balance');
 
         // Approve initial supply tokens.
-        start_prank(CheatTarget::One(memecoin.contract_address), owner);
+        start_prank(CheatTarget::One(memecoin.contract_address), initial_holder_1);
         memecoin.approve(spender, initial_supply);
 
-        // Transfer 100 tokens to recipient.
+        // Transfer 20 tokens to recipient.
         start_prank(CheatTarget::One(memecoin.contract_address), spender);
-        memecoin.transferFrom(owner, recipient, 100.into());
+        memecoin.transferFrom(initial_holder_1, recipient, 20);
 
-        // Check balance. Should be equal to initial supply - 100.
-        let balance = memecoin.balanceOf(owner);
-        assert(balance == (initial_supply - 2 * 50 - 100.into()), 'Invalid balance');
+        // Check balance. Should be equal to initial balance - 20.
+        let initial_holder_1_balance = memecoin.balance_of(initial_holder_1);
+        assert(initial_holder_1_balance == 50 - 20, 'Invalid balance holder 1');
 
-        // Check recipient balance. Should be equal to 100.
-        let balance = memecoin.balanceOf(recipient);
-        assert(balance == 100.into(), 'Invalid balance');
+        // Check recipient balance. Should be equal to 20.
+        let recipient_balance = memecoin.balance_of(recipient);
+        assert(recipient_balance == 20, 'Invalid balance recipient');
 
-        // Check allowance. Should be equal to initial supply - 100.
-        let allowance = memecoin.allowance(owner, spender);
-        assert(allowance == (initial_supply - 100.into()), 'Invalid allowance');
+        // Check allowance. Should be equal to initial supply - transfered amount.
+        let allowance = memecoin.allowance(initial_holder_1, spender);
+        assert(allowance == (initial_supply - 20), 'Invalid allowance');
     }
 }
 
@@ -537,7 +498,6 @@ mod memecoin_entrypoints {
     fn test_launch_memecoin() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -549,13 +509,7 @@ mod memecoin_entrypoints {
             instantiate_params();
         let contract_address =
             match deploy_contract(
-                owner,
-                recipient,
-                name,
-                symbol,
-                initial_supply,
-                initial_holders,
-                initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -575,7 +529,6 @@ mod memecoin_entrypoints {
     fn test_launch_memecoin_not_owner() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -587,13 +540,7 @@ mod memecoin_entrypoints {
             instantiate_params();
         let contract_address =
             match deploy_contract(
-                owner,
-                recipient,
-                name,
-                symbol,
-                initial_supply,
-                initial_holders,
-                initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -608,7 +555,6 @@ mod memecoin_entrypoints {
     fn test_get_team_allocation() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -620,13 +566,7 @@ mod memecoin_entrypoints {
             instantiate_params();
         let contract_address =
             match deploy_contract(
-                owner,
-                recipient,
-                name,
-                symbol,
-                initial_supply,
-                initial_holders,
-                initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -645,22 +585,20 @@ mod memecoin_entrypoints {
     fn test_transfer_max_percentage() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
             initial_holder_1,
             initial_holder_2,
-            _,
+            initial_holders,
             initial_holders_amounts
         ) =
             instantiate_params();
         let alice = contract_address_const::<53>();
-        let initial_holders = array![owner, initial_holder_1, initial_holder_2].span();
 
         let contract_address =
             match deploy_contract(
-                owner, owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -668,14 +606,9 @@ mod memecoin_entrypoints {
 
         let memecoin = IUnruggableMemecoinDispatcher { contract_address };
 
-        // Check initial balance. Should be equal to initial supply.
-        let balance = memecoin.balance_of(owner);
-        assert(balance == initial_supply - 100, 'Invalid balance');
-
-        // Transfer 1 token from owner to alice.
-        start_prank(CheatTarget::One(memecoin.contract_address), owner);
-        let send_amount = memecoin.transfer(alice, 500);
-        assert(memecoin.balance_of(alice) == 500.into(), 'Invalid balance');
+        // Transfer 21 token from owner to alice.
+        start_prank(CheatTarget::One(memecoin.contract_address), initial_holder_1);
+        let send_amount = memecoin.transfer(alice, 21);
     }
 
 
@@ -684,22 +617,20 @@ mod memecoin_entrypoints {
     fn test_transfer_from_max_percentage() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
             initial_holder_1,
             initial_holder_2,
-            _,
+            initial_holders,
             initial_holders_amounts
         ) =
             instantiate_params();
         let alice = contract_address_const::<53>();
-        let initial_holders = array![owner, initial_holder_1, initial_holder_2].span();
 
         let contract_address =
             match deploy_contract(
-                owner, owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -707,36 +638,29 @@ mod memecoin_entrypoints {
 
         let memecoin = IUnruggableMemecoinDispatcher { contract_address };
 
-        // Check initial balance. Should be equal to initial supply.
-        let balance = memecoin.balance_of(owner);
-        assert(balance == initial_supply - 100, 'Invalid balance');
-
-        // Transfer 1 token from owner to alice.
-        start_prank(CheatTarget::One(memecoin.contract_address), owner);
-        let send_amount = memecoin.transfer_from(owner, alice, 500);
-        assert(memecoin.balance_of(alice) == 500.into(), 'Invalid balance');
+        // Transfer 21 token from owner to alice.
+        start_prank(CheatTarget::One(memecoin.contract_address), initial_holder_1);
+        let send_amount = memecoin.transfer_from(initial_holder_1, alice, 500);
     }
 
     #[test]
     fn test_classic_max_percentage() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
             initial_holder_1,
             initial_holder_2,
-            _,
+            initial_holders,
             initial_holders_amounts
         ) =
             instantiate_params();
         let alice = contract_address_const::<53>();
-        let initial_holders = array![owner, initial_holder_1, initial_holder_2].span();
 
         let contract_address =
             match deploy_contract(
-                owner, owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -744,14 +668,10 @@ mod memecoin_entrypoints {
 
         let memecoin = IUnruggableMemecoinDispatcher { contract_address };
 
-        // Check initial balance. Should be equal to initial supply.
-        let balance = memecoin.balance_of(owner);
-        assert(balance == initial_supply - 100, 'Invalid balance');
-
         // Transfer 1 token from owner to alice.
-        start_prank(CheatTarget::One(memecoin.contract_address), owner);
-        let send_amount = memecoin.transfer(alice, 10.into());
-        assert(memecoin.balance_of(alice) == 10.into(), 'Invalid balance');
+        start_prank(CheatTarget::One(memecoin.contract_address), initial_holder_1);
+        let send_amount = memecoin.transfer(alice, 20);
+        assert(memecoin.balance_of(alice) == 20, 'Invalid balance');
     }
 }
 
@@ -768,51 +688,44 @@ mod custom_constructor {
     #[test]
     #[should_panic(expected: ('Unruggable: arrays len dif',))]
     fn test_constructor_initial_holders_arrays_len_mismatch() {
-        let (
-            owner, recipient, name, symbol, initial_supply, initial_holder_1, initial_holder_2, _, _
-        ) =
+        let (owner, name, symbol, initial_supply, initial_holder_1, initial_holder_2, _, _) =
             instantiate_params();
         let initial_holder_3 = contract_address_const::<52>();
         let initial_holder_4 = contract_address_const::<53>();
         let initial_holders = array![
-            recipient, initial_holder_1, initial_holder_2, initial_holder_3, initial_holder_4
+            initial_holder_1, initial_holder_2, initial_holder_3, initial_holder_4
         ]
             .span();
-        let initial_holders_amounts = array![900.into(), 50.into(), 40.into(), 10.into()].span();
+        let initial_holders_amounts = array![50, 40, 10].span();
         match deploy_contract(
-            owner, recipient, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+            owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
         ) {
             Result::Ok(address) => address.print(),
             Result::Err(msg) => panic(msg.panic_data),
         }
     }
+
     #[test]
     fn test_constructor_initial_holders_arrays_len_is_equal() {
-        let (
-            owner, recipient, name, symbol, initial_supply, initial_holder_1, initial_holder_2, _, _
-        ) =
+        let (owner, name, symbol, initial_supply, initial_holder_1, initial_holder_2, _, _) =
             instantiate_params();
         let initial_holder_3 = contract_address_const::<52>();
         // array_len is 4
-        let initial_holders = array![
-            recipient, initial_holder_1, initial_holder_2, initial_holder_3
-        ]
-            .span();
+        let initial_holders = array![initial_holder_1, initial_holder_2, initial_holder_3].span();
         // array_len is 4
-        let initial_holders_amounts = array![900.into(), 50.into(), 40.into(), 10.into()].span();
+        let initial_holders_amounts = array![50, 40, 10].span();
         match deploy_contract(
-            owner, recipient, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+            owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
         ) {
             Result::Ok(address) => {},
             Result::Err(msg) => panic(msg.panic_data),
         }
     }
+
     #[test]
     #[should_panic(expected: ('Unruggable: max holders reached',))]
     fn test_max_holders_reached() {
-        let (
-            owner, recipient, name, symbol, initial_supply, initial_holder_1, initial_holder_2, _, _
-        ) =
+        let (owner, name, symbol, initial_supply, initial_holder_1, initial_holder_2, _, _) =
             instantiate_params();
         let initial_holder_3 = contract_address_const::<52>();
         let initial_holder_4 = contract_address_const::<53>();
@@ -822,9 +735,9 @@ mod custom_constructor {
         let initial_holder_8 = contract_address_const::<57>();
         let initial_holder_9 = contract_address_const::<58>();
         let initial_holder_10 = contract_address_const::<59>();
+        let initial_holder_11 = contract_address_const::<60>();
         // 11 holders
         let initial_holders = array![
-            recipient,
             initial_holder_1,
             initial_holder_2,
             initial_holder_3,
@@ -835,42 +748,28 @@ mod custom_constructor {
             initial_holder_8,
             initial_holder_9,
             initial_holder_10,
+            initial_holder_11,
         ]
             .span();
-        let initial_holders_amounts = array![
-            900.into(),
-            50.into(),
-            42.into(),
-            1.into(),
-            1.into(),
-            1.into(),
-            1.into(),
-            1.into(),
-            1.into(),
-            1.into(),
-            1.into(),
-        ]
-            .span();
+        let initial_holders_amounts = array![1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,].span();
 
         match deploy_contract(
-            owner, recipient, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+            owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
         ) {
             Result::Ok(address) => address.print(),
             Result::Err(msg) => panic(msg.panic_data),
         }
     }
+
     #[test]
     fn test_max_holders_not_reached() {
-        let (
-            owner, recipient, name, symbol, initial_supply, initial_holder_1, initial_holder_2, _, _
-        ) =
+        let (owner, name, symbol, initial_supply, initial_holder_1, initial_holder_2, _, _) =
             instantiate_params();
         let initial_holder_3 = contract_address_const::<52>();
         let initial_holder_4 = contract_address_const::<53>();
         let initial_holder_5 = contract_address_const::<54>();
         // 6 holders
         let initial_holders = array![
-            recipient,
             initial_holder_1,
             initial_holder_2,
             initial_holder_3,
@@ -878,47 +777,20 @@ mod custom_constructor {
             initial_holder_5,
         ]
             .span();
-        let initial_holders_amounts = array![
-            900.into(), 50.into(), 47.into(), 1.into(), 1.into(), 1.into(),
-        ]
-            .span();
+        let initial_holders_amounts = array![50, 47, 1, 1, 1,].span();
 
         match deploy_contract(
-            owner, recipient, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+            owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
         ) {
             Result::Ok(address) => {},
             Result::Err(msg) => panic(msg.panic_data),
         }
     }
-    #[test]
-    #[should_panic(expected: ('initial recipient mismatch',))]
-    fn test_initial_recipient_mismatch() {
-        let (
-            owner,
-            recipient,
-            name,
-            symbol,
-            initial_supply,
-            initial_holder_1,
-            initial_holder_2,
-            _,
-            initial_holders_amounts
-        ) =
-            instantiate_params();
-        let initial_holders = array![initial_holder_1, recipient, initial_holder_2,].span();
 
-        match deploy_contract(
-            owner, recipient, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-        ) {
-            Result::Ok(address) => address.print(),
-            Result::Err(msg) => panic(msg.panic_data),
-        }
-    }
     #[test]
     fn test_initial_recipient_ok() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -930,18 +802,18 @@ mod custom_constructor {
             instantiate_params();
 
         match deploy_contract(
-            owner, recipient, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+            owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
         ) {
             Result::Ok(address) => {},
             Result::Err(msg) => panic(msg.panic_data),
         }
     }
+
     #[test]
     #[should_panic(expected: ('Unruggable: max team allocation',))]
     fn test_max_team_allocation_fail() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -952,19 +824,19 @@ mod custom_constructor {
         ) =
             instantiate_params();
         // team should have less than 100 tokens
-        let initial_holders_amounts = array![900.into(), 100.into(), 50.into(),].span();
+        let initial_holders_amounts = array![100, 50,].span();
         match deploy_contract(
-            owner, recipient, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+            owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
         ) {
             Result::Ok(address) => address.print(),
             Result::Err(msg) => panic(msg.panic_data),
         }
     }
+
     #[test]
     fn test_max_team_allocation_ok() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -975,19 +847,19 @@ mod custom_constructor {
         ) =
             instantiate_params();
         // team should have less than 100 tokens
-        let initial_holders_amounts = array![900.into(), 50.into(), 50.into(),].span();
+        let initial_holders_amounts = array![50, 50,].span();
         match deploy_contract(
-            owner, recipient, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+            owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
         ) {
             Result::Ok(address) => {},
             Result::Err(msg) => panic(msg.panic_data),
         }
     }
+
     #[test]
     fn test_max_team_allocation_ok2() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -998,43 +870,19 @@ mod custom_constructor {
         ) =
             instantiate_params();
         // team should have less than 100 tokens
-        let initial_holders_amounts = array![900.into(), 50.into(), 40.into(),].span();
+        let initial_holders_amounts = array![50, 40,].span();
         match deploy_contract(
-            owner, recipient, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+            owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
         ) {
             Result::Ok(address) => {},
             Result::Err(msg) => panic(msg.panic_data),
         }
     }
-    #[test]
-    #[should_panic(expected: ('Unruggable: max supply reached',))]
-    fn test_max_supply_reached_fail() {
-        let (
-            owner,
-            recipient,
-            name,
-            symbol,
-            initial_supply,
-            initial_holder_1,
-            initial_holder_2,
-            initial_holders,
-            _
-        ) =
-            instantiate_params();
-        // team should have less than 100 tokens
-        let initial_holders_amounts = array![910.into(), 50.into(), 50.into(),].span();
-        match deploy_contract(
-            owner, recipient, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-        ) {
-            Result::Ok(address) => address.print(),
-            Result::Err(msg) => panic(msg.panic_data),
-        }
-    }
+
     #[test]
     fn test_max_supply_reached_ok() {
         let (
             owner,
-            recipient,
             name,
             symbol,
             initial_supply,
@@ -1044,10 +892,10 @@ mod custom_constructor {
             _
         ) =
             instantiate_params();
-        // team should have less than 100 tokens
-        let initial_holders_amounts = array![900.into(), 50.into(), 50.into(),].span();
+        // team should have less than 101 tokens
+        let initial_holders_amounts = array![50, 50].span();
         match deploy_contract(
-            owner, recipient, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+            owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
         ) {
             Result::Ok(address) => {},
             Result::Err(msg) => panic(msg.panic_data),
@@ -1073,15 +921,20 @@ mod memecoin_internals {
     #[test]
     fn test__transfer_recipients_equal_holder_cap() {
         let (
-            owner, recipient, name, symbol, initial_supply, initial_holder_1, initial_holder_2, _, _
+            owner,
+            name,
+            symbol,
+            initial_supply,
+            initial_holder_1,
+            initial_holder_2,
+            initial_holders,
+            initial_holders_amounts,
         ) =
             instantiate_params();
-        let initial_holders = array![owner, initial_holder_1, initial_holder_2].span();
-        let initial_holders_amounts = array![900.into(), 50.into(), 30.into(),].span();
 
         let contract_address =
             match deploy_contract(
-                owner, owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -1089,26 +942,30 @@ mod memecoin_internals {
 
         let memecoin = IUnruggableMemecoinDispatcher { contract_address };
 
+        // set initial_holder_1 as caller to distribute tokens
+        start_prank(CheatTarget::One(memecoin.contract_address), initial_holder_1);
+
         let mut index = 0;
         loop {
-            // MAX_HOLDERS_BEFORE_LAUNCH - 3 because there are 3 initial holders
-            if index == MAX_HOLDERS_BEFORE_LAUNCH - 3 {
+            // MAX_HOLDERS_BEFORE_LAUNCH - 2 because there are 2 initial holders
+            if index == MAX_HOLDERS_BEFORE_LAUNCH - 2 {
                 break;
             }
 
-            // Transfer 1 token to the unique recipient
             // create a unique address
             let unique_recipient: ContractAddress = (index.into() + 9999).try_into().unwrap();
-            start_prank(CheatTarget::One(memecoin.contract_address), owner);
-            memecoin.transfer(unique_recipient, 1.into());
+
+            // Transfer 1 token to the unique recipient
+            memecoin.transfer(unique_recipient, 1);
 
             // Check recipient balance. Should be equal to 1.
             let recipient_balance = memecoin.balanceOf(unique_recipient);
-            assert(recipient_balance == 1.into(), 'Invalid balance recipient');
+            assert(recipient_balance == 1, 'Invalid balance recipient');
 
             index += 1;
         };
     }
+
     #[test]
     fn test__transfer_existing_holders() {
         /// pre launch holder number should not change when
@@ -1118,15 +975,19 @@ mod memecoin_internals {
         /// and ensure that we can transfer more than `MAX_HOLDERS_BEFORE_LAUNCH` times
 
         let (
-            owner, recipient, name, symbol, initial_supply, initial_holder_1, initial_holder_2, _, _
+            owner,
+            name,
+            symbol,
+            initial_supply,
+            initial_holder_1,
+            initial_holder_2,
+            initial_holders,
+            initial_holders_amounts,
         ) =
             instantiate_params();
-        let initial_holders = array![owner, initial_holder_1, initial_holder_2].span();
-        let initial_holders_amounts = array![900.into(), 50.into(), 30.into(),].span();
-
         let contract_address =
             match deploy_contract(
-                owner, owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
             ) {
             Result::Ok(address) => address,
             Result::Err(msg) => panic(msg.panic_data),
@@ -1134,79 +995,8 @@ mod memecoin_internals {
 
         let memecoin = IUnruggableMemecoinDispatcher { contract_address };
 
-        let mut index = 0;
-        loop {
-            if index == MAX_HOLDERS_BEFORE_LAUNCH - 3 {
-                break;
-            }
-
-            // Self transfer tokens
-
-            start_prank(CheatTarget::One(memecoin.contract_address), owner);
-            memecoin.transfer(initial_holder_2, 1.into());
-
-            index += 1;
-        };
-    }
-    #[test]
-    #[should_panic(expected: ('Unruggable: max holders reached',))]
-    fn test__transfer_above_holder_cap() {
-        let (
-            owner, recipient, name, symbol, initial_supply, initial_holder_1, initial_holder_2, _, _
-        ) =
-            instantiate_params();
-        let initial_holders = array![owner, initial_holder_1, initial_holder_2].span();
-        let initial_holders_amounts = array![900.into(), 50.into(), 30.into(),].span();
-
-        let contract_address =
-            match deploy_contract(
-                owner, owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-            ) {
-            Result::Ok(address) => address,
-            Result::Err(msg) => panic(msg.panic_data),
-        };
-
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
-
-        let mut index = 0;
-        loop {
-            // There are already 3 holders, so MAX_HOLDERS_BEFORE_LAUNCH - 2 should break
-            if index == MAX_HOLDERS_BEFORE_LAUNCH - 2 {
-                break;
-            }
-
-            // Transfer 1 token to the unique recipient
-            let unique_recipient: ContractAddress = (index.into() + 9999).try_into().unwrap();
-            start_prank(CheatTarget::One(memecoin.contract_address), owner);
-            memecoin.transfer(unique_recipient, 1.into());
-
-            index += 1;
-        };
-    }
-    #[test]
-    fn test__transfer_no_holder_cap_after_launch() {
-        let (
-            owner, recipient, name, symbol, initial_supply, initial_holder_1, initial_holder_2, _, _
-        ) =
-            instantiate_params();
-        let initial_holders = array![owner, initial_holder_1, initial_holder_2].span();
-        let initial_holders_amounts = array![900.into(), 50.into(), 30.into(),].span();
-
-        let contract_address =
-            match deploy_contract(
-                owner, owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-            ) {
-            Result::Ok(address) => address,
-            Result::Err(msg) => panic(msg.panic_data),
-        };
-
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
-
-        // set owner as caller to bypass owner restrictions
-        start_prank(CheatTarget::All, owner);
-
-        // launch memecoin
-        memecoin.launch_memecoin();
+        // set initial_holder_1 as caller to distribute tokens
+        start_prank(CheatTarget::One(memecoin.contract_address), initial_holder_1);
 
         let mut index = 0;
         loop {
@@ -1214,9 +1004,103 @@ mod memecoin_internals {
                 break;
             }
 
-            // Transfer 1 token to the unique recipient
+            // Self transfer tokens
+            memecoin.transfer(initial_holder_2, 1);
+
+            index += 1;
+        };
+    }
+
+    #[test]
+    #[should_panic(expected: ('Unruggable: max holders reached',))]
+    fn test__transfer_above_holder_cap() {
+        let (
+            owner,
+            name,
+            symbol,
+            initial_supply,
+            initial_holder_1,
+            initial_holder_2,
+            initial_holders,
+            _
+        ) =
+            instantiate_params();
+        let initial_holders_amounts = array![50, 30].span();
+
+        let contract_address =
+            match deploy_contract(
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+            ) {
+            Result::Ok(address) => address,
+            Result::Err(msg) => panic(msg.panic_data),
+        };
+
+        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
+
+        // set initial_holder_1 as caller to distribute tokens
+        start_prank(CheatTarget::One(memecoin.contract_address), initial_holder_1);
+
+        let mut index = 0;
+        loop {
+            if index == MAX_HOLDERS_BEFORE_LAUNCH {
+                break;
+            }
+
+            // create a unique address
             let unique_recipient: ContractAddress = (index.into() + 9999).try_into().unwrap();
-            memecoin.transfer(unique_recipient, 1.into());
+
+            // Transfer 1 token to the unique recipient
+            memecoin.transfer(unique_recipient, 1);
+
+            index += 1;
+        };
+    }
+
+    #[test]
+    fn test__transfer_no_holder_cap_after_launch() {
+        let (
+            owner,
+            name,
+            symbol,
+            initial_supply,
+            initial_holder_1,
+            initial_holder_2,
+            initial_holders,
+            _
+        ) =
+            instantiate_params();
+        let initial_holders_amounts = array![50, 30,].span();
+
+        let contract_address =
+            match deploy_contract(
+                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
+            ) {
+            Result::Ok(address) => address,
+            Result::Err(msg) => panic(msg.panic_data),
+        };
+
+        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
+
+        // set owner as caller to launch the token
+        start_prank(CheatTarget::All, owner);
+
+        // launch memecoin
+        memecoin.launch_memecoin();
+
+        // set initial_holder_1 as caller to distribute tokens
+        start_prank(CheatTarget::All, initial_holder_1);
+
+        let mut index = 0;
+        loop {
+            if index == MAX_HOLDERS_BEFORE_LAUNCH {
+                break;
+            }
+
+            // create a unique address
+            let unique_recipient: ContractAddress = (index.into() + 9999).try_into().unwrap();
+
+            // Transfer 1 token to the unique recipient
+            memecoin.transfer(unique_recipient, 1);
 
             index += 1;
         };


### PR DESCRIPTION
Resolves #77.

Also brings some modifications to the `_enforce_holders_limit` internal.  The method can also decrease holders count if the sender has no tokens left after the transfer.

Lastly, it might be interesting to discuss about adding additional checks in the `_enforce_holders_limit` such as asserting the `amount` param or `recipient` are not null. With current ERC20 implementation, those checks are useless, but it makes this method rely on ERC20 behaviour. Without those checks, this method is a kind of ERC20 extension, which is not a bad design, but also not necessarily what we want.