### PR TITLE
Delay that bypasses transfer limit

### DIFF
--- a/contracts/src/tokens/factory.cairo
+++ b/contracts/src/tokens/factory.cairo
@@ -194,7 +194,9 @@ mod UnruggableMemecoinFactory {
         symbol: felt252,
         initial_supply: u256
     ) -> Array<felt252> {
-        let mut calldata = array![owner.into(), locker_address.into(), 1000.into(), name.into(), symbol.into()]; // Third param should be lock delay.
+        let mut calldata = array![
+            owner.into(), locker_address.into(), 1000.into(), name.into(), symbol.into()
+        ]; // Third param should be lock delay.
         Serde::serialize(@initial_supply, ref calldata);
         calldata
     }

--- a/contracts/src/tokens/factory.cairo
+++ b/contracts/src/tokens/factory.cairo
@@ -194,7 +194,7 @@ mod UnruggableMemecoinFactory {
         symbol: felt252,
         initial_supply: u256
     ) -> Array<felt252> {
-        let mut calldata = array![owner.into(), locker_address.into(), name.into(), symbol.into()];
+        let mut calldata = array![owner.into(), locker_address.into(), 1000.into(), name.into(), symbol.into()]; // Third param should be lock delay.
         Serde::serialize(@initial_supply, ref calldata);
         calldata
     }

--- a/contracts/src/tokens/memecoin.cairo
+++ b/contracts/src/tokens/memecoin.cairo
@@ -11,7 +11,8 @@ mod UnruggableMemecoin {
     use openzeppelin::token::erc20::ERC20Component;
     use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
     use starknet::{
-        ContractAddress, contract_address_const, get_contract_address, get_caller_address, get_block_timestamp
+        ContractAddress, contract_address_const, get_contract_address, get_caller_address,
+        get_block_timestamp
     };
     use unruggable::amm::amm::{AMM, AMMV2};
     use unruggable::amm::jediswap_interface::{
@@ -118,7 +119,11 @@ mod UnruggableMemecoin {
         // Initialize the token / internal logic
         self
             ._initializer(
-                locker_address, limit_delay, :initial_supply, :initial_holders, :initial_holders_amounts
+                locker_address,
+                limit_delay,
+                :initial_supply,
+                :initial_holders,
+                :initial_holders_amounts
             );
     }
 
@@ -405,7 +410,7 @@ mod UnruggableMemecoin {
             let launch_time = self.launch_time.read();
             let transfer_delay = self.transfer_delay.read();
             let current_time = get_block_timestamp();
-            if(current_time < (launch_time + transfer_delay) || launch_time == 0_u64) {
+            if (current_time < (launch_time + transfer_delay) || launch_time == 0_u64) {
                 let locker_address = self.locker_contract.read();
                 if (sender != locker_address && recipient != locker_address) {
                     assert(

--- a/contracts/tests/test_token_locker.cairo
+++ b/contracts/tests/test_token_locker.cairo
@@ -22,7 +22,7 @@ fn setup() -> (ContractAddress, ContractAddress, ContractAddress) {
     let initial_holders_amounts: Span<u256> = array![1000, 50].span();
 
     let mut token_calldata = array![
-        owner.into(), locker_address.into(), 'TEST', 'TST', 100000.into(), 0.into()
+        owner.into(), locker_address.into(), 1000.into(), 'TEST', 'TST', 100000.into(), 0.into()
     ];
 
     let amms: Array<AMM> = array![];

--- a/contracts/tests/test_unruggable_memecoin.cairo
+++ b/contracts/tests/test_unruggable_memecoin.cairo
@@ -34,7 +34,7 @@ fn deploy_contract(
 ) -> Result<ContractAddress, RevertedTransaction> {
     let contract = declare('UnruggableMemecoin');
     let mut constructor_calldata = array![
-        owner.into(), 'locker', name, symbol, initial_supply.low.into(), initial_supply.high.into()
+        owner.into(), 'locker', 1000.into(), name, symbol, initial_supply.low.into(), initial_supply.high.into()
     ];
     let amms: Array<AMM> = array![];
     Serde::serialize(@amms.into(), ref constructor_calldata);
@@ -172,7 +172,7 @@ mod erc20_entrypoints {
     use core::debug::PrintTrait;
     use core::traits::Into;
     use openzeppelin::token::erc20::interface::IERC20;
-    use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank, CheatTarget};
+    use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank, start_warp, CheatTarget};
     use starknet::{ContractAddress, contract_address_const};
     use super::{deploy_contract, instantiate_params};
     use unruggable::tokens::interface::{
@@ -486,7 +486,7 @@ mod memecoin_entrypoints {
     use debug::PrintTrait;
 
     use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
-    use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank, CheatTarget};
+    use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank, start_warp, CheatTarget};
     use starknet::{ContractAddress, contract_address_const};
     use super::{deploy_contract, instantiate_params};
     use unruggable::amm::amm::{AMM, AMMV2};

--- a/contracts/tests/test_unruggable_memecoin.cairo
+++ b/contracts/tests/test_unruggable_memecoin.cairo
@@ -34,7 +34,13 @@ fn deploy_contract(
 ) -> Result<ContractAddress, RevertedTransaction> {
     let contract = declare('UnruggableMemecoin');
     let mut constructor_calldata = array![
-        owner.into(), 'locker', 1000.into(), name, symbol, initial_supply.low.into(), initial_supply.high.into()
+        owner.into(),
+        'locker',
+        1000.into(),
+        name,
+        symbol,
+        initial_supply.low.into(),
+        initial_supply.high.into()
     ];
     let amms: Array<AMM> = array![];
     Serde::serialize(@amms.into(), ref constructor_calldata);
@@ -172,7 +178,9 @@ mod erc20_entrypoints {
     use core::debug::PrintTrait;
     use core::traits::Into;
     use openzeppelin::token::erc20::interface::IERC20;
-    use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank, start_warp, CheatTarget};
+    use snforge_std::{
+        declare, ContractClassTrait, start_prank, stop_prank, start_warp, CheatTarget
+    };
     use starknet::{ContractAddress, contract_address_const};
     use super::{deploy_contract, instantiate_params};
     use unruggable::tokens::interface::{
@@ -486,7 +494,9 @@ mod memecoin_entrypoints {
     use debug::PrintTrait;
 
     use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
-    use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank, start_warp, CheatTarget};
+    use snforge_std::{
+        declare, ContractClassTrait, start_prank, stop_prank, start_warp, CheatTarget
+    };
     use starknet::{ContractAddress, contract_address_const};
     use super::{deploy_contract, instantiate_params};
     use unruggable::amm::amm::{AMM, AMMV2};


### PR DESCRIPTION
The test is not implemented. We need to have a function that successfully launches memecoin then we will be able to test that.
The test will be simple. Just increase the timestamp by 1000 after calling `launch_memecoin`

On the factory side, I passed `1000_u64` as the third param of the constructor of memecoin. It has to be changed by how you gonna use it from the factory.