### PR TITLE
add `contract_address_salt` in `create_memecoin` factory method

### DIFF
--- a/contracts/src/tokens/factory.cairo
+++ b/contracts/src/tokens/factory.cairo
@@ -13,6 +13,7 @@ trait IUnruggableMemecoinFactory<TContractState> {
         initial_supply: u256,
         initial_holders: Span<ContractAddress>,
         initial_holders_amounts: Span<u256>,
+        contract_address_salt: felt252
     ) -> ContractAddress;
 }
 
@@ -102,6 +103,7 @@ mod UnruggableMemecoinFactory {
         /// * `initial_supply` - The initial supply of the Memecoin.
         /// * `initial_holders` - An array containing the initial holders' addresses.
         /// * `initial_holders_amounts` - An array containing the initial amounts held by each corresponding initial holder.
+        /// * `contract_address_salt` - A unique salt value for contract deployment
         ///
         /// # Returns
         ///
@@ -115,9 +117,8 @@ mod UnruggableMemecoinFactory {
             initial_supply: u256,
             initial_holders: Span<ContractAddress>,
             initial_holders_amounts: Span<u256>,
+            contract_address_salt: felt252
         ) -> ContractAddress {
-            let contract_address_salt = generate_salt(owner, name, symbol);
-
             // General calldata
             let mut calldata = serialize_calldata(
                 owner, locker_address, name, symbol, initial_supply
@@ -197,24 +198,5 @@ mod UnruggableMemecoinFactory {
         let mut calldata = array![owner.into(), locker_address.into(), name.into(), symbol.into()];
         Serde::serialize(@initial_supply, ref calldata);
         calldata
-    }
-
-
-    /// Generates a unique salt.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - The address of the contract owner.
-    /// * `name` - The name of the contract.
-    /// * `symbol` - The symbol of the contract.
-    ///
-    /// # Returns
-    ///
-    /// A unique salt value (felt252) for contract function execution.
-    fn generate_salt(owner: ContractAddress, name: felt252, symbol: felt252) -> felt252 {
-        let mut data = array![
-            owner.into(), name.into(), symbol.into(), starknet::get_block_timestamp().into()
-        ];
-        poseidon_hash_span(data.span())
     }
 }

--- a/contracts/tests/test_unruggable_memecoin.cairo
+++ b/contracts/tests/test_unruggable_memecoin.cairo
@@ -518,6 +518,7 @@ mod memecoin_entrypoints {
         let router_dispatcher = IRouterC1Dispatcher { contract_address: router_address };
 
         let (owner, name, symbol, _, _, initial_holder_2, _, _) = instantiate_params();
+        let contract_address_salt = 'salty';
         let initial_holders = array![owner].span();
         let initial_holders_amounts = array![1 * TOKEN_MULTIPLIER].span();
 
@@ -549,7 +550,8 @@ mod memecoin_entrypoints {
                 symbol,
                 initial_supply,
                 initial_holders,
-                initial_holders_amounts
+                initial_holders_amounts,
+                contract_address_salt
             );
 
         let unruggable_memecoin = IUnruggableMemecoinDispatcher {
@@ -571,6 +573,7 @@ mod memecoin_entrypoints {
         let (_, router_address) = deploy_contracts();
         let router_dispatcher = IRouterC1Dispatcher { contract_address: router_address };
         let (owner, name, symbol, _, _, _, _, _) = instantiate_params();
+        let contract_address_salt = 'salty';
         let initial_holders = array![owner].span();
         let initial_holders_amounts = array![1 * TOKEN_MULTIPLIER].span();
 
@@ -604,7 +607,8 @@ mod memecoin_entrypoints {
                 symbol,
                 initial_supply,
                 initial_holders,
-                initial_holders_amounts
+                initial_holders_amounts,
+                contract_address_salt
             );
         let unruggable_memecoin = IUnruggableMemecoinDispatcher {
             contract_address: memecoin_address
@@ -619,13 +623,13 @@ mod memecoin_entrypoints {
     // NOTE:
     // 1. The initial call to `memecoin_address` should be made by the owner.
     // 2. Subsequently, the router needs to call memecoin to transfer tokens to the pool.
-    // 3. The second call to `memecoin_address` should be made by the router. 
+    // 3. The second call to `memecoin_address` should be made by the router.
     //    However, note that the prank still designates owner as the caller.
     // `set_contract_address()` from starknet cannot be used in this context.
     // related issue: https://github.com/foundry-rs/starknet-foundry/issues/1402
 
     // If we want to test this now (without the foundry fix), we need to comment
-    // out the assert_only_owner() in the launch_memecoin() method in memecoin.cairo. 
+    // out the assert_only_owner() in the launch_memecoin() method in memecoin.cairo.
     // Then, we can uncomment the following lines, and this will make the test pass.
     // start_prank(CheatTarget::One(router_address), memecoin_address);
     // let pool_address = unruggable_memecoin
@@ -662,6 +666,8 @@ mod memecoin_entrypoints {
         ) =
             instantiate_params();
 
+        let contract_address_salt = 'salty';
+
         let initial_holders = array![owner].span();
         let initial_holders_amounts = array![1 * TOKEN_MULTIPLIER].span();
 
@@ -695,7 +701,8 @@ mod memecoin_entrypoints {
                 symbol,
                 initial_supply,
                 initial_holders,
-                initial_holders_amounts
+                initial_holders_amounts,
+                contract_address_salt
             );
         let unruggable_memecoin = IUnruggableMemecoinDispatcher {
             contract_address: memecoin_address
@@ -713,7 +720,7 @@ mod memecoin_entrypoints {
             .launch_memecoin(
                 AMMV2::JediSwap,
                 counterparty_token_address,
-                // this is +1 of initial supply - split to owner 
+                // this is +1 of initial supply - split to owner
                 100 * TOKEN_MULTIPLIER,
                 1 * TOKEN_MULTIPLIER
             );
@@ -727,6 +734,7 @@ mod memecoin_entrypoints {
         let (_, router_address) = deploy_contracts();
         let router_dispatcher = IRouterC1Dispatcher { contract_address: router_address };
         let (owner, name, symbol, _, _, _, _, _) = instantiate_params();
+        let contract_address_salt = 'salty';
         let initial_holders = array![owner].span();
         let initial_holders_amounts = array![1 * TOKEN_MULTIPLIER].span();
 
@@ -761,7 +769,8 @@ mod memecoin_entrypoints {
                 symbol,
                 initial_supply,
                 initial_holders,
-                initial_holders_amounts
+                initial_holders_amounts,
+                contract_address_salt
             );
 
         let unruggable_memecoin = IUnruggableMemecoinDispatcher {
@@ -1381,12 +1390,12 @@ mod memecoin_internals {
         // NOTE:
         // 1. The initial call to `memecoin_address` should be made by the owner.
         // 2. Subsequently, the router needs to call memecoin to transfer tokens to the pool.
-        // 3. The second call to `memecoin_address` should be made by the router. 
+        // 3. The second call to `memecoin_address` should be made by the router.
         //    However, note that the prank still designates owner as the caller.
         // `set_contract_address()` from starknet cannot be used in this context.
         // related issue: https://github.com/foundry-rs/starknet-foundry/issues/1402
 
-        // start_prank(CheatTarget::One(memecoin_address), router_address); 
+        // start_prank(CheatTarget::One(memecoin_address), router_address);
         // start_prank(CheatTarget::One(router_address), memecoin_address);
         // unruggable_memecoin
         //     .launch_memecoin(

--- a/contracts/tests/test_unruggable_memecoin_factory.cairo
+++ b/contracts/tests/test_unruggable_memecoin_factory.cairo
@@ -21,6 +21,7 @@ fn instantiate_params() -> (
     ContractAddress,
     Span<ContractAddress>,
     Span<u256>,
+    felt252
 ) {
     let owner = contract_address_const::<42>();
     let name = 'UnruggableMemecoin';
@@ -30,6 +31,7 @@ fn instantiate_params() -> (
     let initial_holder_2 = contract_address_const::<45>();
     let initial_holders = array![initial_holder_1, initial_holder_2].span();
     let initial_holders_amounts = array![50, 50].span();
+    let contract_address_salt = 'salty';
     (
         owner,
         name,
@@ -38,7 +40,8 @@ fn instantiate_params() -> (
         initial_holder_1,
         initial_holder_2,
         initial_holders,
-        initial_holders_amounts
+        initial_holders_amounts,
+        contract_address_salt
     )
 }
 
@@ -96,7 +99,8 @@ fn test_deploy_memecoin() {
         initial_holder_1,
         initial_holder_2,
         initial_holders,
-        initial_holders_amounts
+        initial_holders_amounts,
+        contract_address_salt
     ) =
         instantiate_params();
 
@@ -106,13 +110,14 @@ fn test_deploy_memecoin() {
 
     let memecoin_address = memecoin_factory
         .create_memecoin(
-            owner,
-            locker_address,
-            name,
-            symbol,
-            initial_supply,
-            initial_holders,
-            initial_holders_amounts
+            :owner,
+            :locker_address,
+            :name,
+            :symbol,
+            :initial_supply,
+            :initial_holders,
+            :initial_holders_amounts,
+            :contract_address_salt
         );
     let memecoin = IUnruggableMemecoinDispatcher { contract_address: memecoin_address };
 


### PR DESCRIPTION
Providing contract address salt in factory calldata makes it easier for FE usage