### PR TITLE
move AMM mgmt from token to factory

### DIFF
--- a/contracts/tests/test_token_locker.cairo
+++ b/contracts/tests/test_token_locker.cairo
@@ -25,9 +25,6 @@ fn setup() -> (ContractAddress, ContractAddress, ContractAddress) {
         owner.into(), locker_address.into(), 'TEST', 'TST', 100000.into(), 0.into()
     ];
 
-    let amms: Array<AMM> = array![];
-    Serde::serialize(@amms.into(), ref token_calldata);
-
     Serde::serialize(@initial_holders.into(), ref token_calldata);
     Serde::serialize(@initial_holders_amounts.into(), ref token_calldata);
 

--- a/contracts/tests/test_unruggable_memecoin.cairo
+++ b/contracts/tests/test_unruggable_memecoin.cairo
@@ -36,8 +36,6 @@ fn deploy_contract(
     let mut constructor_calldata = array![
         owner.into(), 'locker', name, symbol, initial_supply.low.into(), initial_supply.high.into()
     ];
-    let amms: Array<AMM> = array![];
-    Serde::serialize(@amms.into(), ref constructor_calldata);
 
     Serde::serialize(@initial_holders.into(), ref constructor_calldata);
     Serde::serialize(@initial_holders_amounts.into(), ref constructor_calldata);

--- a/contracts/tests/test_unruggable_memecoin_factory.cairo
+++ b/contracts/tests/test_unruggable_memecoin_factory.cairo
@@ -46,7 +46,7 @@ fn instantiate_params() -> (
 }
 
 #[test]
-fn test_deploy_factory_register_amms() {
+fn test_deploy_factory_amm_router_address() {
     let (_, router_address) = deploy_contracts();
 
     // Declare UnruggableMemecoin and use ClassHash for the Factory
@@ -65,10 +65,8 @@ fn test_deploy_factory_register_amms() {
         contract_address: memecoin_factory_address
     };
 
-    let amms: Span<AMM> = memecoin_factory.registered_amms();
-    assert(amms.len() == 1, 'wrong amm len');
-    assert((*amms.at(0)).name == jediswap_name, 'wrong amm name');
-    assert((*amms.at(0)).router_address == router_address, 'wrong amm router_address');
+    let amm_router_address = memecoin_factory.amm_router_address(amm_name: jediswap_name);
+    assert(amm_router_address == router_address, 'wrong amm router_address');
 }
 
 #[test]


### PR DESCRIPTION
move AMM mgmt from token to factory and keep the same calldata for `create_memecoin` and token constructor