### PR TITLE
fix deadline

### DIFF
--- a/contracts/src/tokens/interface.cairo
+++ b/contracts/src/tokens/interface.cairo
@@ -45,7 +45,8 @@ trait IUnruggableMemecoin<TState> {
         amm_v2: AMMV2,
         counterparty_token_address: ContractAddress,
         liquidity_memecoin_amount: u256,
-        liquidity_counterparty_token: u256
+        liquidity_counterparty_token: u256,
+        deadline:u64
     ) -> ContractAddress;
     fn get_team_allocation(self: @TState) -> u256;
 }
@@ -83,7 +84,8 @@ trait IUnruggableAdditional<TState> {
         amm_v2: AMMV2,
         counterparty_token_address: ContractAddress,
         liquidity_memecoin_amount: u256,
-        liquidity_counterparty_token: u256
+        liquidity_counterparty_token: u256,
+        deadline:u64
     ) -> ContractAddress;
     fn get_team_allocation(self: @TState) -> u256;
 }

--- a/contracts/src/tokens/interface.cairo
+++ b/contracts/src/tokens/interface.cairo
@@ -46,7 +46,7 @@ trait IUnruggableMemecoin<TState> {
         counterparty_token_address: ContractAddress,
         liquidity_memecoin_amount: u256,
         liquidity_counterparty_token: u256,
-        deadline:u64
+        deadline: u64
     ) -> ContractAddress;
     fn get_team_allocation(self: @TState) -> u256;
 }
@@ -85,7 +85,7 @@ trait IUnruggableAdditional<TState> {
         counterparty_token_address: ContractAddress,
         liquidity_memecoin_amount: u256,
         liquidity_counterparty_token: u256,
-        deadline:u64
+        deadline: u64
     ) -> ContractAddress;
     fn get_team_allocation(self: @TState) -> u256;
 }

--- a/contracts/src/tokens/memecoin.cairo
+++ b/contracts/src/tokens/memecoin.cairo
@@ -136,6 +136,7 @@ mod UnruggableMemecoin {
         /// - `counterparty_token_address`: The contract address of the counterparty token.
         /// - `liquidity_memecoin_amount`: The amount of Memecoin tokens to be provided as liquidity.
         /// - `liquidity_counterparty_token`: The amount of counterparty tokens to be provided as liquidity.
+        /// - `deadline`: The deadline beyond which the operation will revert.
         ///
         /// # Panics
         /// This method will panic if:
@@ -151,6 +152,7 @@ mod UnruggableMemecoin {
             counterparty_token_address: ContractAddress,
             liquidity_memecoin_amount: u256,
             liquidity_counterparty_token: u256,
+            deadline:u64
         ) -> ContractAddress {
             // [Check Owner] Only the owner can launch the Memecoin
             self.ownable.assert_only_owner();
@@ -200,7 +202,7 @@ mod UnruggableMemecoin {
                     1, // amount_a_min
                     1, // amount_b_min
                     memecoin_address,
-                    0, // deadline
+                    deadline, // deadline
                 );
 
             // Launch the coin

--- a/contracts/src/tokens/memecoin.cairo
+++ b/contracts/src/tokens/memecoin.cairo
@@ -152,7 +152,7 @@ mod UnruggableMemecoin {
             counterparty_token_address: ContractAddress,
             liquidity_memecoin_amount: u256,
             liquidity_counterparty_token: u256,
-            deadline:u64
+            deadline: u64
         ) -> ContractAddress {
             // [Check Owner] Only the owner can launch the Memecoin
             self.ownable.assert_only_owner();

--- a/contracts/tests/test_unruggable_memecoin.cairo
+++ b/contracts/tests/test_unruggable_memecoin.cairo
@@ -484,7 +484,7 @@ mod memecoin_entrypoints {
     use debug::PrintTrait;
 
     use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
-    use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank, CheatTarget};
+    use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank, CheatTarget,start_warp};
     use starknet::{ContractAddress, contract_address_const};
     use super::{deploy_contract, instantiate_params};
     use unruggable::amm::amm::{AMM, AMMV2};
@@ -561,7 +561,8 @@ mod memecoin_entrypoints {
                 AMMV2::JediSwap,
                 counterparty_token_address,
                 1 * TOKEN_MULTIPLIER,
-                1 * TOKEN_MULTIPLIER
+                1 * TOKEN_MULTIPLIER,
+                100
             );
     }
 
@@ -635,7 +636,8 @@ mod memecoin_entrypoints {
     //         AMMV2::JediSwap,
     //         counterparty_token_address,
     //         5 * TOKEN_MULTIPLIER,
-    //         2 * TOKEN_MULTIPLIER
+    //         2 * TOKEN_MULTIPLIER,
+    //         100
     //     );
 
     // let pool_dispatcher = IPairDispatcher { contract_address: pool_address };
@@ -720,7 +722,8 @@ mod memecoin_entrypoints {
                 counterparty_token_address,
                 // this is +1 of initial supply - split to owner
                 100 * TOKEN_MULTIPLIER,
-                1 * TOKEN_MULTIPLIER
+                1 * TOKEN_MULTIPLIER,
+                100
             );
         stop_prank(CheatTarget::One(memecoin_address));
     }
@@ -788,10 +791,95 @@ mod memecoin_entrypoints {
                 AMMV2::JediSwap,
                 counterparty_token_address,
                 1 * TOKEN_MULTIPLIER,
-                1 * TOKEN_MULTIPLIER
+                1 * TOKEN_MULTIPLIER,
+                100
             );
         stop_prank(CheatTarget::One(memecoin_address));
     }
+
+
+    #[test]
+    #[should_panic(expected: ('expired',))]
+    fn test_launch_memecoin_deadline_expired() {
+        // Setup
+        let (_, router_address) = deploy_contracts();
+        let router_dispatcher = IRouterC1Dispatcher { contract_address: router_address };
+        let (owner, name, symbol, _, _, _, _, _) = instantiate_params();
+        let contract_address_salt = 'salty';
+        let initial_holders = array![owner].span();
+        let initial_holders_amounts = array![1 * TOKEN_MULTIPLIER].span();
+
+        let initial_supply: u256 = 100 * TOKEN_MULTIPLIER;
+        let counterparty_token_address = deploy_erc20(initial_supply, owner);
+
+        // Declare availables AMMs for this factory
+        let mut amms = array![];
+        amms.append(AMM { name: AMMV2::JediSwap.into(), router_address });
+
+        // Declare UnruggableMemecoin and use ClassHash for the Factory
+        let declare_memecoin = declare('UnruggableMemecoin');
+        let memecoin_factory_address = deploy_memecoin_factory(
+            owner, declare_memecoin.class_hash, amms
+        );
+
+        // Deploy UnruggableMemecoinFactory
+        let unruggable_meme_factory = IUnruggableMemecoinFactoryDispatcher {
+            contract_address: memecoin_factory_address
+        };
+
+        let locker_calldata = array![200];
+        let locker_contract = declare('TokenLocker');
+        let locker_address = locker_contract.deploy(@locker_calldata).unwrap();
+
+        // Create a MemeCoin
+        let memecoin_address = unruggable_meme_factory
+            .create_memecoin(
+                owner,
+                locker_address,
+                name,
+                symbol,
+                initial_supply,
+                initial_holders,
+                initial_holders_amounts,
+                contract_address_salt
+            );
+
+        // Change the block timestamp for Router and Memecoin
+        start_warp(CheatTarget::One(memecoin_address), 1000);
+        start_warp(CheatTarget::One(router_address), 1000);
+
+
+        let unruggable_memecoin = IUnruggableMemecoinDispatcher {
+            contract_address: memecoin_address
+        };
+
+        let token_dispatcher = IERC20Dispatcher { contract_address: counterparty_token_address };
+
+        // Transfer 0.02 (2% of 100 * TOKEN_MULTIPLIER) memecoin to UnruggableMemecoin contract
+        start_prank(CheatTarget::One(memecoin_address), owner);
+        unruggable_memecoin.transfer(memecoin_address, 1 * TOKEN_MULTIPLIER);
+        stop_prank(CheatTarget::One(memecoin_address));
+
+
+        let token_dispatcher = IERC20Dispatcher { contract_address: counterparty_token_address };
+        // Transfer 1 counterparty_token to UnruggableMemecoin contract
+        start_prank(CheatTarget::One(counterparty_token_address), owner);
+        token_dispatcher.transfer(memecoin_address, 5 * TOKEN_MULTIPLIER);
+        stop_prank(CheatTarget::One(counterparty_token_address));
+
+        start_prank(CheatTarget::One(memecoin_address), owner);
+        unruggable_memecoin
+            .launch_memecoin(
+                AMMV2::JediSwap,
+                counterparty_token_address,
+                1 * TOKEN_MULTIPLIER,
+                1 * TOKEN_MULTIPLIER,
+                100
+            );
+        stop_prank(CheatTarget::One(memecoin_address));
+    }
+
+
 
     #[test]
     fn test_get_team_allocation() {

--- a/contracts/tests/test_unruggable_memecoin.cairo
+++ b/contracts/tests/test_unruggable_memecoin.cairo
@@ -484,7 +484,9 @@ mod memecoin_entrypoints {
     use debug::PrintTrait;
 
     use openzeppelin::token::erc20::interface::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
-    use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank, CheatTarget,start_warp};
+    use snforge_std::{
+        declare, ContractClassTrait, start_prank, stop_prank, CheatTarget, start_warp
+    };
     use starknet::{ContractAddress, contract_address_const};
     use super::{deploy_contract, instantiate_params};
     use unruggable::amm::amm::{AMM, AMMV2};
@@ -848,7 +850,6 @@ mod memecoin_entrypoints {
         start_warp(CheatTarget::One(memecoin_address), 1000);
         start_warp(CheatTarget::One(router_address), 1000);
 
-
         let unruggable_memecoin = IUnruggableMemecoinDispatcher {
             contract_address: memecoin_address
         };
@@ -859,7 +860,6 @@ mod memecoin_entrypoints {
         start_prank(CheatTarget::One(memecoin_address), owner);
         unruggable_memecoin.transfer(memecoin_address, 1 * TOKEN_MULTIPLIER);
         stop_prank(CheatTarget::One(memecoin_address));
-
 
         let token_dispatcher = IERC20Dispatcher { contract_address: counterparty_token_address };
         // Transfer 1 counterparty_token to UnruggableMemecoin contract
@@ -878,7 +878,6 @@ mod memecoin_entrypoints {
             );
         stop_prank(CheatTarget::One(memecoin_address));
     }
-
 
 
     #[test]


### PR DESCRIPTION
# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Testing
- Bugfix


## What is the current behavior?

Current  `add_liquidity()`  function use `0` as deadline but this will always revert. Because for router contracts deadline should be bigger than current timestamp.
```
amm_router
    .add_liquidity(
        memecoin_address,
        counterparty_token_address,
        liquidity_memecoin_amount,
        liquidity_counterparty_token,
        1, // amount_a_min
        1, // amount_b_min
        memecoin_address,
        0, // deadline
    );

```

## What is the new behavior?

It is not good practise to use a constant as a deadline so I added a deadline as input.

```
      fn launch_memecoin(
          ref self: ContractState,
          amm_v2: AMMV2,
          counterparty_token_address: ContractAddress,
          liquidity_memecoin_amount: u256,
          liquidity_counterparty_token: u256,
          deadline:u64
      ) -> ContractAddress {


```