### PR TITLE
refactor: clean memecoin impl

### DIFF
--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -74,7 +74,7 @@ mod Factory {
     }
 
     #[abi(embed_v0)]
-    impl UnruggableMemeCoinFactoryImpl of IFactory<ContractState> {
+    impl FactoryImpl of IFactory<ContractState> {
         fn create_memecoin(
             ref self: ContractState,
             owner: ContractAddress,
@@ -84,13 +84,18 @@ mod Factory {
             initial_supply: u256,
             initial_holders: Span<ContractAddress>,
             initial_holders_amounts: Span<u256>,
-            eth_contract: ERC20ABIDispatcher,
-            contract_address_salt: felt252
+            transfer_limit_delay: u64,
+            counterparty_token: ERC20ABIDispatcher,
+            contract_address_salt: felt252,
         ) -> ContractAddress {
-            // General calldata
-            let mut calldata = serialize_calldata(
-                owner, locker_address, name, symbol, initial_supply
-            );
+            let mut calldata = array![
+                owner.into(),
+                locker_address.into(),
+                transfer_limit_delay.into(),
+                name.into(),
+                symbol.into()
+            ];
+            Serde::serialize(@initial_supply, ref calldata);
             Serde::serialize(@initial_holders.into(), ref calldata);
             Serde::serialize(@initial_holders_amounts.into(), ref calldata);
 
@@ -105,18 +110,9 @@ mod Factory {
             let caller = get_caller_address();
             //TODO(make the initial liquidity a parameter)
             let eth_amount: u256 = 1 * ETH_UNIT_DECIMALS;
-            assert(
-                eth_contract.allowance(caller, get_contract_address()) == eth_amount,
-                'ETH allowance not enough'
-            );
-            eth_contract
+
+            counterparty_token
                 .transferFrom(sender: caller, recipient: memecoin_address, amount: eth_amount);
-
-            //TODO(audit): why does it matter if the coin has _more_ than 1 ETH?
-            assert(
-                eth_contract.balanceOf(memecoin_address) == eth_amount, 'memecoin should have 1ETH'
-            );
-
             self.emit(MemeCoinCreated { owner, name, symbol, initial_supply, memecoin_address });
 
             memecoin_address
@@ -129,33 +125,5 @@ mod Factory {
         fn is_memecoin(self: @ContractState, address: ContractAddress) -> bool {
             self.deployed_memecoins.read(address)
         }
-    }
-
-    /// Serializes input parameters into calldata.
-    ///
-    /// # Arguments
-    ///
-    /// * `owner` - The address of the contract owner.
-    /// * `locker_address` - The address of the locker contract associated with the contract.
-    /// * `name` - The name of the contract.
-    /// * `symbol` - The symbol of the contract.
-    /// * `initial_supply` - The initial supply of the contract.
-    ///
-    /// # Returns
-    ///
-    /// An array containing the serialized calldata.
-    fn serialize_calldata(
-        owner: ContractAddress,
-        locker_address: ContractAddress,
-        name: felt252,
-        symbol: felt252,
-        initial_supply: u256
-    ) -> Array<felt252> {
-        //TODO(fix): serialize_calldata shouldn't have a hardcoded value here. - or at least, it should be named.
-        let mut calldata = array![
-            owner.into(), locker_address.into(), 1000.into(), name.into(), symbol.into()
-        ]; // Third param should be lock delay.
-        Serde::serialize(@initial_supply, ref calldata);
-        calldata
     }
 }

--- a/contracts/src/factory/interface.cairo
+++ b/contracts/src/factory/interface.cairo
@@ -3,7 +3,7 @@ use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IFactory<TContractState> {
-    /// Creates a new memecoin.
+    /// Deploys a new memecoin, using the class hash that was registered in the factory upon initialization.
     ///
     /// This function deploys a new memecoin contract with the given parameters,
     /// transfers 1 ETH from the caller to the new memecoin, and emits a `MemeCoinCreated` event.
@@ -15,6 +15,8 @@ trait IFactory<TContractState> {
     /// * `initial_supply` - The initial supply of the Memecoin.
     /// * `initial_holders` - An array containing the initial holders' addresses.
     /// * `initial_holders_amounts` - An array containing the initial amounts held by each corresponding initial holder.
+    /// * `transfer_limit_delay` - The delay in seconds during which transfers will be limited to a % of max supply after launch.
+    /// * `counterparty_token` - The address of the counterparty token
     /// * `contract_address_salt` - A unique salt value for contract deployment
     ///
     /// # Returns
@@ -29,7 +31,8 @@ trait IFactory<TContractState> {
         initial_supply: u256,
         initial_holders: Span<ContractAddress>,
         initial_holders_amounts: Span<u256>,
-        eth_contract: ERC20ABIDispatcher,
+        transfer_limit_delay: u64,
+        counterparty_token: ERC20ABIDispatcher,
         contract_address_salt: felt252
     ) -> ContractAddress;
 

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -6,6 +6,10 @@ mod locker;
 mod tests;
 mod tokens;
 
+mod utils {
+    mod math;
+}
+
 mod mocks {
     mod erc20;
     mod jediswap {

--- a/contracts/src/locker/token_locker.cairo
+++ b/contracts/src/locker/token_locker.cairo
@@ -1,6 +1,5 @@
 //TODO(low prio): implement fallback mechanism for snake_case entrypoints
 //TODO(low prio): implement a recover functions for tokens wrongly sent to the contract
-//TODO(high prio): keep a list of all active locks per users.
 #[starknet::contract]
 mod TokenLocker {
     use alexandria_storage::list::{List, ListTrait};

--- a/contracts/src/tests/test_factory.cairo
+++ b/contracts/src/tests/test_factory.cairo
@@ -5,7 +5,7 @@ use unruggable::amm::amm::{AMM, AMMV2, AMMTrait};
 use unruggable::factory::{IFactory, IFactoryDispatcher, IFactoryDispatcherTrait};
 use unruggable::tests::utils::{
     deploy_amm_factory_and_router, deploy_meme_factory, deploy_locker, deploy_eth, OWNER, NAME,
-    SYMBOL, ETH_INITIAL_SUPPLY, INITIAL_HOLDERS, INITIAL_HOLDERS_AMOUNTS, SALT
+    SYMBOL, DEFAULT_INITIAL_SUPPLY, INITIAL_HOLDERS, INITIAL_HOLDERS_AMOUNTS, SALT
 };
 use unruggable::tokens::interface::{
     IUnruggableMemecoin, IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
@@ -44,10 +44,11 @@ fn test_is_memecoin() {
             :locker_address,
             name: NAME(),
             symbol: SYMBOL(),
-            initial_supply: ETH_INITIAL_SUPPLY(),
+            initial_supply: DEFAULT_INITIAL_SUPPLY(),
             initial_holders: INITIAL_HOLDERS(),
             initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
-            eth_contract: eth,
+            transfer_limit_delay: 1000,
+            counterparty_token: eth,
             contract_address_salt: SALT(),
         );
     stop_prank(CheatTarget::One(memecoin_factory.contract_address));
@@ -82,10 +83,11 @@ fn test_create_memecoin() {
             :locker_address,
             name: NAME(),
             symbol: SYMBOL(),
-            initial_supply: ETH_INITIAL_SUPPLY(),
+            initial_supply: DEFAULT_INITIAL_SUPPLY(),
             initial_holders: INITIAL_HOLDERS(),
             initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
-            eth_contract: eth,
+            transfer_limit_delay: 1000,
+            counterparty_token: eth,
             contract_address_salt: SALT(),
         );
     stop_prank(CheatTarget::One(memecoin_factory.contract_address));
@@ -96,7 +98,8 @@ fn test_create_memecoin() {
     assert(memecoin.symbol() == SYMBOL(), 'wrong memecoin symbol');
     // initial supply - initial holder balance
     assert(
-        memecoin.balanceOf(memecoin_address) == ETH_INITIAL_SUPPLY() - 100, 'wrong initial supply'
+        memecoin.balanceOf(memecoin_address) == DEFAULT_INITIAL_SUPPLY() - 100,
+        'wrong initial supply'
     );
     assert(memecoin.balanceOf(*INITIAL_HOLDERS()[0]) == 50, 'wrong initial_holder_1 balance');
     assert(memecoin.balanceOf(*INITIAL_HOLDERS()[1]) == 50, 'wrong initial_holder_2 balance');

--- a/contracts/src/tests/test_token_locker.cairo
+++ b/contracts/src/tests/test_token_locker.cairo
@@ -18,6 +18,8 @@ use unruggable::tokens::interface::{
 const DEFAULT_LOCK_DEADLINE: u64 = 300;
 const DEFAULT_LOCK_AMOUNT: u256 = 100;
 
+/// Sets up the locker contract and deploys a token contract.
+/// For simplicity, the token deployed is the default "ETH" token.
 fn setup() -> (ERC20ABIDispatcher, ITokenLockerDispatcher) {
     let (token, token_address) = deploy_eth();
     let locker = deploy_locker();

--- a/contracts/src/tests/utils.cairo
+++ b/contracts/src/tests/utils.cairo
@@ -46,6 +46,10 @@ fn SALT() -> felt252 {
     'salty'.try_into().unwrap()
 }
 
+fn DEFAULT_INITIAL_SUPPLY() -> u256 {
+    21_000_000 * pow_256(10, 18)
+}
+
 
 trait TxInfoMockTrait {
     fn default() -> TxInfoMock;
@@ -199,10 +203,11 @@ fn deploy_memecoin() -> ContractAddress {
             :locker_address,
             name: NAME(),
             symbol: SYMBOL(),
-            initial_supply: ETH_INITIAL_SUPPLY(),
+            initial_supply: DEFAULT_INITIAL_SUPPLY(),
             initial_holders: INITIAL_HOLDERS(),
             initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
-            eth_contract: eth,
+            transfer_limit_delay: 1000,
+            counterparty_token: eth,
             contract_address_salt: SALT(),
         );
     stop_prank(CheatTarget::One(memecoin_factory.contract_address));

--- a/contracts/src/tokens/interface.cairo
+++ b/contracts/src/tokens/interface.cairo
@@ -41,7 +41,7 @@ trait IUnruggableMemecoin<TState> {
     ///     bool: whether token has launched
     fn launched(self: @TState) -> bool;
     fn launch_memecoin(
-        ref self: TState, amm_v2: AMMV2, counterparty_token_address: ContractAddress, deadline: u64
+        ref self: TState, amm_v2: AMMV2, counterparty_token_address: ContractAddress,
     ) -> ContractAddress;
     fn get_team_allocation(self: @TState) -> u256;
 }
@@ -75,7 +75,7 @@ trait IUnruggableAdditional<TState> {
     ///     bool: whether token has launched
     fn launched(self: @TState) -> bool;
     fn launch_memecoin(
-        ref self: TState, amm_v2: AMMV2, counterparty_token_address: ContractAddress, deadline: u64
+        ref self: TState, amm_v2: AMMV2, counterparty_token_address: ContractAddress,
     ) -> ContractAddress;
     fn get_team_allocation(self: @TState) -> u256;
 }

--- a/contracts/src/tokens/memecoin.cairo
+++ b/contracts/src/tokens/memecoin.cairo
@@ -22,15 +22,13 @@ mod UnruggableMemecoin {
         IRouterC1DispatcherTrait
     };
 
-    use unruggable::errors::{
-        MAX_HOLDERS_REACHED, ARRAYS_LEN_DIF, MAX_TEAM_ALLOCATION_REACHED, AMM_NOT_SUPPORTED
-    };
+    use unruggable::errors;
     use unruggable::factory::{IFactory, IFactoryDispatcher, IFactoryDispatcherTrait};
     use unruggable::locker::{ITokenLockerDispatcher, ITokenLockerDispatcherTrait};
     use unruggable::tokens::interface::{
         IUnruggableMemecoinSnake, IUnruggableMemecoinCamel, IUnruggableAdditional
     };
-
+    use unruggable::utils::math::PercentageMath;
 
     // Components.
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -66,7 +64,7 @@ mod UnruggableMemecoin {
         team_allocation: u256,
         tx_hash_tracker: LegacyMap<ContractAddress, felt252>,
         locker_contract: ContractAddress,
-        transfer_delay: u64,
+        transfer_limit_delay: u64,
         launch_time: u64,
         factory_contract: ContractAddress,
         // Components.
@@ -89,7 +87,7 @@ mod UnruggableMemecoin {
     /// # Arguments
     /// * `owner` - The owner of the contract.
     /// * `locker_address` - Token locker address.
-    /// * `limit_delay` - Delay timestamp to release transfer amount check.
+    /// * `transfer_limit_delay` - Delay timestamp to release transfer amount check.
     /// * `name` - The name of the token.
     /// * `symbol` - The symbol of the token.
     /// * `initial_supply` - The initial supply of the token.
@@ -100,7 +98,7 @@ mod UnruggableMemecoin {
         ref self: ContractState,
         owner: ContractAddress,
         locker_address: ContractAddress,
-        limit_delay: u64,
+        transfer_limit_delay: u64,
         name: felt252,
         symbol: felt252,
         initial_supply: u256,
@@ -117,10 +115,10 @@ mod UnruggableMemecoin {
         let factory_address = get_caller_address();
 
         self
-            ._initializer(
-                locker_address,
-                limit_delay,
+            .initializer(
+                :locker_address,
                 :factory_address,
+                :transfer_limit_delay,
                 :initial_supply,
                 :initial_holders,
                 :initial_holders_amounts
@@ -141,24 +139,21 @@ mod UnruggableMemecoin {
         /// The owner must send tokens of the chosen counterparty (e.g., USDC) to launch Memecoin.
         ///
         /// # Arguments
-        /// - `amm_v2`: AMMV2 to create a pair and send liquidity.
-        /// - `liquidity_memecoin_amount`: The amount of Memecoin tokens to be provided as liquidity.
-        /// - `liquidity_counterparty_token`: The amount of counterparty tokens to be provided as liquidity.
-        /// - `deadline`: The deadline beyond which the operation will revert.
+        /// * `amm_v2`: AMMV2 to create a pair and send liquidity.
+        /// * `liquidity_memecoin_amount`: The amount of Memecoin tokens to be provided as liquidity.
+        /// * `liquidity_counterparty_token`: The amount of counterparty tokens to be provided as liquidity.
+        /// * `deadline`: The deadline beyond which the operation will revert.
         ///
         /// # Panics
         /// This method will panic if:
-        /// - The caller is not the owner of the contract.
-        /// - Insufficient Memecoin funds are available for liquidity.
-        /// - Insufficient counterparty token funds are available for liquidity.
+        /// * The caller is not the owner of the contract.
+        /// * Insufficient Memecoin funds are available for liquidity.
+        /// * Insufficient counterparty token funds are available for liquidity.
         ///
         /// # Returns
-        /// Returns the contract address of the created liquidity pool.
+        /// * `ContractAddress` - The contract address of the created liquidity pool.
         fn launch_memecoin(
-            ref self: ContractState,
-            amm_v2: AMMV2,
-            counterparty_token_address: ContractAddress,
-            deadline: u64
+            ref self: ContractState, amm_v2: AMMV2, counterparty_token_address: ContractAddress,
         ) -> ContractAddress {
             // [Check Owner] Only the owner can launch the Memecoin
             self.ownable.assert_only_owner();
@@ -171,7 +166,7 @@ mod UnruggableMemecoin {
 
             // [Create Pool]
             let amm_router = IRouterC1Dispatcher { contract_address: router_address };
-            assert(amm_router.contract_address.is_non_zero(), AMM_NOT_SUPPORTED);
+            assert(amm_router.contract_address.is_non_zero(), errors::AMM_NOT_SUPPORTED);
 
             let amm_factory = IFactoryC1Dispatcher { contract_address: amm_router.factory(), };
             let pair_address = amm_factory
@@ -179,32 +174,31 @@ mod UnruggableMemecoin {
 
             // [Check Balance]
             let memecoin_balance = self.balanceOf(memecoin_address);
-            let counterparty_token_dispatcher = ERC20ABIDispatcher {
+            let counterparty_token = ERC20ABIDispatcher {
                 contract_address: counterparty_token_address,
             };
-            let counterparty_token_balance = counterparty_token_dispatcher
-                .balanceOf(memecoin_address);
+            let counterparty_token_balance = counterparty_token.balanceOf(memecoin_address);
 
             // [Approve]
-            self._approve(memecoin_address, amm_router.contract_address, memecoin_balance);
-            counterparty_token_dispatcher
-                .approve(amm_router.contract_address, counterparty_token_balance);
+            self.erc20._approve(memecoin_address, amm_router.contract_address, memecoin_balance);
+            counterparty_token.approve(amm_router.contract_address, counterparty_token_balance);
 
-            // [Add liquidity]
+            // As we're supplying the first liquidity for this pool,
+            // The expected minimum amounts for each tokens are the amounts we're supplying.
             let (amount_memecoin, amount_eth, liquidity_received) = amm_router
                 .add_liquidity(
                     memecoin_address,
                     counterparty_token_address,
                     memecoin_balance,
                     counterparty_token_balance,
-                    1, // amount_a_min
-                    1, // amount_b_min
+                    memecoin_balance,
+                    counterparty_token_balance,
                     memecoin_address,
-                    deadline, // deadline
+                    deadline: get_block_timestamp() + 10, // deadline should be in this same block
                 );
             assert(self.balanceOf(pair_address) == memecoin_balance, 'add liquidity meme failed');
             assert(
-                counterparty_token_dispatcher.balanceOf(pair_address) == counterparty_token_balance,
+                counterparty_token.balanceOf(pair_address) == counterparty_token_balance,
                 'add liquidity eth failed'
             );
             let pair = ERC20ABIDispatcher { contract_address: pair_address, };
@@ -249,24 +243,26 @@ mod UnruggableMemecoin {
         // * snake_case functions
         // ************************************
         fn total_supply(self: @ContractState) -> u256 {
-            self.erc20.ERC20_total_supply.read()
+            self.erc20.total_supply()
         }
 
         fn balance_of(self: @ContractState, account: ContractAddress) -> u256 {
-            self.erc20.ERC20_balances.read(account)
+            self.erc20.balance_of(account)
         }
 
         fn allowance(
             self: @ContractState, owner: ContractAddress, spender: ContractAddress
         ) -> u256 {
-            self.erc20.ERC20_allowances.read((owner, spender))
+            self.erc20.allowance(owner, spender)
         }
 
         fn transfer(ref self: ContractState, recipient: ContractAddress, amount: u256) -> bool {
             let sender = get_caller_address();
             self.ensure_not_multicall(recipient);
-            self._check_max_buy_percentage(sender, recipient, amount);
-            self._transfer(sender, recipient, amount);
+            self.enforce_max_transfer_percentage(sender, recipient, amount);
+            self.enforce_prelaunch_holders_limit(sender, recipient, amount);
+
+            self.erc20.transfer(recipient, amount);
             true
         }
 
@@ -276,33 +272,30 @@ mod UnruggableMemecoin {
             recipient: ContractAddress,
             amount: u256
         ) -> bool {
-            let caller = get_caller_address();
             // When we call launch_memecoin(), we invoke the add_liquidity() of the router,
-            // which performs a transfer_from() to send the tokens to the pool.
+            // which performs a transferFrom() to send the tokens to the pool.
             // Therefore, we need to bypass this validation if the sender is the memecoin contract.
             if sender != get_contract_address() {
                 self.ensure_not_multicall(sender);
-                self._check_max_buy_percentage(sender, recipient, amount);
+                self.enforce_max_transfer_percentage(sender, recipient, amount);
+                self.enforce_prelaunch_holders_limit(sender, recipient, amount);
             }
-            self.erc20._spend_allowance(sender, caller, amount);
-            self.erc20._transfer(sender, recipient, amount);
+            self.erc20.transfer_from(sender, recipient, amount);
             true
         }
 
         fn approve(ref self: ContractState, spender: ContractAddress, amount: u256) -> bool {
-            let caller = get_caller_address();
-            self.erc20._approve(caller, spender, amount);
-            true
+            self.erc20.approve(spender, amount)
         }
     }
 
     #[abi(embed_v0)]
     impl CamelEntrypoints of IUnruggableMemecoinCamel<ContractState> {
         fn totalSupply(self: @ContractState) -> u256 {
-            self.erc20.ERC20_total_supply.read()
+            self.total_supply()
         }
         fn balanceOf(self: @ContractState, account: ContractAddress) -> u256 {
-            self.erc20.ERC20_balances.read(account)
+            self.balance_of(account)
         }
         fn transferFrom(
             ref self: ContractState,
@@ -310,7 +303,7 @@ mod UnruggableMemecoin {
             recipient: ContractAddress,
             amount: u256
         ) -> bool {
-            return self.transfer_from(sender, recipient, amount);
+            self.transfer_from(sender, recipient, amount)
         }
     }
 
@@ -319,121 +312,46 @@ mod UnruggableMemecoin {
     //
     #[generate_trait]
     impl UnruggableMemecoinInternalImpl of UnruggableMemecoinInternalTrait {
-        /// Internal function to enforce pre launch holder limit
+        // Initializes the state of the memecoin contract.
         ///
-        /// Note that when transfers are done, between addresses that already
-        /// hold tokens, we do not increment the number of holders. it only
-        /// gets incremented when the recipient that hold no tokens.
-        /// But if the sender will no longer hold tokens after the transfer,
-        /// the number of holders is decremented.
+        /// This function sets the locker and factory contract addresses, enables a transfer limit delay,
+        /// checks and allocates the team supply of the memecoin, and mints the remaining supply to the contract itself.
         ///
         /// # Arguments
-        /// * `sender` - The sender of the tokens being transferred.
-        /// * `recipient` - The recipient of the tokens being transferred.
-        /// * `amount` - The amount of tokens being transferred.
-        #[inline(always)]
-        fn _enforce_holders_limit(
+        ///
+        /// * `locker_address` - The address of the locker contract.
+        /// * `factory_address` - The address of the factory contract.
+        /// * `transfer_limit_delay` - The delay in seconds before transfers are no longer limited.
+        /// * `initial_supply` - The initial supply of the memecoin.
+        /// * `initial_holders` - A span of addresses that will hold the memecoin initially.
+        /// * `initial_holders_amounts` - A span of amounts corresponding to the initial holders.
+        ///
+        fn initializer(
             ref self: ContractState,
-            sender: ContractAddress,
-            recipient: ContractAddress,
-            amount: u256
+            locker_address: ContractAddress,
+            factory_address: ContractAddress,
+            transfer_limit_delay: u64,
+            initial_supply: u256,
+            initial_holders: Span<ContractAddress>,
+            initial_holders_amounts: Span<u256>
         ) {
-            if !self.launched.read() {
-                // if the sender will no longer hold tokens
-                if sender.is_non_zero() && self.balanceOf(sender) == amount {
-                    let current_holders_count = self.pre_launch_holders_count.read();
+            // Internal Registry
+            self.locker_contract.write(locker_address);
+            self.factory_contract.write(factory_address);
 
-                    // decrease holders count
-                    self.pre_launch_holders_count.write(current_holders_count - 1);
-                }
+            // Enable a transfer limit - until this time has passed,
+            // transfers are limited to a certain amount.
+            self.transfer_limit_delay.write(transfer_limit_delay);
 
-                // if the recipient doesn't hold tokens yet
-                if self.balanceOf(recipient).is_zero() {
-                    let current_holders_count = self.pre_launch_holders_count.read();
+            let team_allocation = self
+                .check_and_allocate_team_supply(
+                    :initial_supply, :initial_holders, :initial_holders_amounts
+                );
 
-                    // assert max holders limit is not reached
-                    assert(current_holders_count < MAX_HOLDERS_BEFORE_LAUNCH, MAX_HOLDERS_REACHED);
-
-                    // increase holders count
-                    self.pre_launch_holders_count.write(current_holders_count + 1);
-                }
-            }
-        }
-
-        /// Internal function to mint tokens
-        ///
-        /// Before minting, a check is done to ensure that
-        /// only `MAX_HOLDERS_BEFORE_LAUNCH` addresses can hold
-        /// tokens if token hasn't launched
-        ///
-        /// # Arguments
-        /// * `recipient` - The recipient of the tokens.
-        /// * `amount` - The amount of tokens to be minted.
-        fn _mint(ref self: ContractState, recipient: ContractAddress, amount: u256) {
-            self._enforce_holders_limit(sender: contract_address_const::<0>(), :recipient, :amount);
-            self.erc20._mint(recipient, amount);
-        }
-
-        /// Internal function to transfer tokens
-        ///
-        /// Before transferring, a check is done to ensure that
-        /// only `MAX_HOLDERS_BEFORE_LAUNCH` addresses can hold
-        /// tokens if token hasn't launched
-        ///
-        /// # Arguments
-        /// * `sender` - The sender or owner of the tokens.
-        /// * `recipient` - The recipient of the tokens.
-        /// * `amount` - The amount of tokens to be transferred.
-        fn _transfer(
-            ref self: ContractState,
-            sender: ContractAddress,
-            recipient: ContractAddress,
-            amount: u256
-        ) {
-            self._enforce_holders_limit(:sender, :recipient, :amount);
-            self.erc20._transfer(sender, recipient, amount);
-        }
-
-        /// Internal function to approve spending of tokens.
-        ///
-        /// # Arguments
-        ///
-        /// * `self` - A mutable reference to the contract state.
-        /// * `owner` - The owner of the tokens.
-        /// * `spender` - The address allowed to spend the tokens.
-        /// * `amount` - The amount of tokens to be approved for spending.
-        fn _approve(
-            ref self: ContractState, owner: ContractAddress, spender: ContractAddress, amount: u256
-        ) {
-            self.erc20._approve(owner, spender, amount);
-        }
-
-        /// Internal function to assert the buy limit is not reached
-        ///
-        /// This check ensure that an address cannot buy more
-        /// than the maximum percentage of the supply that can
-        /// be bought at once.
-        ///
-        /// # Arguments
-        /// * `amount` - The amount of tokens being transferred.
-        #[inline(always)]
-        fn _check_max_buy_percentage(
-            self: @ContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256
-        ) {
-            let launch_time = self.launch_time.read();
-            let transfer_delay = self.transfer_delay.read();
-            let current_time = get_block_timestamp();
-            if (current_time < (launch_time + transfer_delay) || launch_time == 0_u64) {
-                let locker_address = self.locker_contract.read();
-                if (sender != locker_address && recipient != locker_address) {
-                    assert(
-                        self.erc20.ERC20_total_supply.read()
-                            * MAX_PERCENTAGE_BUY_LAUNCH.into()
-                            / 10_000 >= amount,
-                        'Max buy cap reached'
-                    )
-                }
-            }
+            // Mint remaining supply to the contract
+            self
+                .erc20
+                ._mint(recipient: get_contract_address(), amount: initial_supply - team_allocation);
         }
 
         /// Ensures that the current call is not a part of a multicall.
@@ -452,78 +370,149 @@ mod UnruggableMemecoin {
             self.tx_hash_tracker.write(recipient, tx_hash);
         }
 
-        /// Cons\tructor logic.
+        /// Checks and allocates the team supply of the memecoin.
+        ///
+        /// Checks that the number of initial holders and their corresponding amounts are equal,
+        /// and that the number of initial holders does not exceed the maximum allowed.
+        /// It then calculates the maximum team allocation as a percentage of the initial supply,
+        /// and iteratively allocates the supply to each initial holder, ensuring that the total allocation does not exceed the maximu authorized.
+        /// The function then updates the `team_allocation` and `pre_launch_holders_count` in the contract state.
+        ///
         /// # Arguments
-        /// * `locker_address` - Token locker contract address.
-        /// * `limit_delay` - Delay timestamp to release transfer amount check.
-        /// * `factory_address` - Token factory contract address.
-        /// * `initial_supply` - The initial supply of the token.
-        /// * `initial_holders` - The initial holders of the token, an array of holder_address
-        /// * `initial_holders_amounts` - The initial amounts of tokens minted to the initial holders, an array of amounts
-        fn _initializer(
+        ///
+        /// * `initial_supply` - The initial supply of the memecoin.
+        /// * `initial_holders` - A span of addresses that will hold the memecoin initially.
+        /// * `initial_holders_amounts` - A span of amounts corresponding to the initial holders.
+        ///
+        /// # Returns
+        ///
+        /// * `u256` - The total amount of memecoin allocated to the team.
+        ///
+        fn check_and_allocate_team_supply(
             ref self: ContractState,
-            locker_address: ContractAddress,
-            limit_delay: u64,
-            factory_address: ContractAddress,
             initial_supply: u256,
             initial_holders: Span<ContractAddress>,
             initial_holders_amounts: Span<u256>
-        ) {
-            // save locker contract
-            self.locker_contract.write(locker_address);
-            self.transfer_delay.write(limit_delay);
+        ) -> u256 {
+            assert(initial_holders.len() == initial_holders_amounts.len(), errors::ARRAYS_LEN_DIF);
+            assert(
+                initial_holders.len() <= MAX_HOLDERS_BEFORE_LAUNCH.into(),
+                errors::MAX_HOLDERS_REACHED
+            );
 
-            // save factory contract
-            self.factory_contract.write(factory_address);
-
-            let mut team_allocation: u256 = 0;
             let max_team_allocation = initial_supply
-                * MAX_SUPPLY_PERCENTAGE_TEAM_ALLOCATION.into()
-                / 10_000;
+                .percent_mul(MAX_SUPPLY_PERCENTAGE_TEAM_ALLOCATION.into());
+            let mut team_allocation: u256 = 0;
             let mut i: usize = 0;
-
-            // check initial holders len match
-            assert(initial_holders.len() == initial_holders_amounts.len(), ARRAYS_LEN_DIF);
-
-            // check on max holders count
-            assert(initial_holders.len() <= MAX_HOLDERS_BEFORE_LAUNCH.into(), MAX_HOLDERS_REACHED);
-
             loop {
-                if i >= initial_holders.len() {
+                if i == initial_holders.len() {
                     break;
                 }
 
                 let address = *initial_holders.at(i);
                 let amount = *initial_holders_amounts.at(i);
 
-                // increase team allocation
                 team_allocation += amount;
+                assert(team_allocation <= max_team_allocation, errors::MAX_TEAM_ALLOCATION_REACHED);
 
-                // check on max team allocation
-                assert(team_allocation <= max_team_allocation, MAX_TEAM_ALLOCATION_REACHED);
-
-                // mint to holder using the erc20 internal to avoid triggering pre launch safeguards and waste gas.
+                // Mint token to the holder
                 self.erc20._mint(recipient: address, :amount);
 
                 i += 1;
             };
-
-            // mint remaining supply to the contract
-            self
-                .erc20
-                ._mint(recipient: get_contract_address(), amount: initial_supply - team_allocation);
-
-            // save team allocation
             self.team_allocation.write(team_allocation);
-
-            // save pre launch holders count
             self.pre_launch_holders_count.write(initial_holders.len().try_into().unwrap());
-        }
-    }
 
-    fn _get_eth_address() -> ContractAddress {
-        contract_address_const::<
-            0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-        >()
+            team_allocation
+        }
+
+        /// Enforces that the number of holders does not exceed the maximum allowed.
+        ///
+        /// When transfers are done between addresses that already
+        /// own tokens, we do not increment the number of holders.
+        /// It only gets incremented when the recipient holds no tokens.
+        /// If the sender will no longer hold tokens after the transfer, the
+        /// number of holders is decremented.
+        ///
+        /// # Arguments
+        ///
+        /// * `sender` - The sender of the tokens being transferred.
+        /// * `recipient` - The recipient of the tokens being transferred.
+        /// * `amount` - The amount of tokens being transferred.
+        ///
+        #[inline(always)]
+        fn enforce_prelaunch_holders_limit(
+            ref self: ContractState,
+            sender: ContractAddress,
+            recipient: ContractAddress,
+            amount: u256
+        ) {
+            if self.launched.read() {
+                return;
+            }
+
+            // If this is not a mint and the sender will no longer hold tokens after the transfer,
+            // decrement the holders count.
+            //TODO: verify whether sender can _actually_ be zero - as this function is called from _transfer,
+            // which is supposedly not called from the zero address.
+            if sender.is_non_zero() && self.balanceOf(sender) == amount {
+                let current_holders_count = self.pre_launch_holders_count.read();
+
+                self.pre_launch_holders_count.write(current_holders_count - 1);
+            }
+
+            // If the recipient doesn't hold tokens yet - increment the holders count
+            if self.balanceOf(recipient).is_zero() {
+                let current_holders_count = self.pre_launch_holders_count.read();
+
+                assert(
+                    current_holders_count < MAX_HOLDERS_BEFORE_LAUNCH, errors::MAX_HOLDERS_REACHED
+                );
+
+                self.pre_launch_holders_count.write(current_holders_count + 1);
+            }
+        }
+
+
+        /// Enforces the maximum transfer percentage during the launch phase.
+        ///
+        /// Checks if the coin has launched and if the transfer limit delay has passed.
+        /// If not, it checks if the sender or recipient is the locker contract.
+        /// If neither is the locker contract, it asserts that the transfer amount does not exceed a certain percentage of the total supply.
+        ///
+        /// # Arguments
+        ///
+        /// * `sender` - The address of the sender.
+        /// * `recipient` - The address of the recipient.
+        /// * `amount` - The amount to be transferred.
+        ///
+        /// # Panics
+        ///
+        /// * If the transfer amount exceeds the maximum allowed percentage of the total supply during the launch phase.
+        ///
+        #[inline(always)]
+        fn enforce_max_transfer_percentage(
+            self: @ContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256
+        ) {
+            let launch_time = self.launch_time.read();
+            let transfer_limit_delay = self.transfer_limit_delay.read();
+            let current_time = get_block_timestamp();
+            let locker_address = self.locker_contract.read();
+
+            // Skip if the coin is launched and the transfer limit delay has passed
+            if (launch_time != 0_u64 && current_time >= (launch_time + transfer_limit_delay)) {
+                return;
+            }
+
+            // Skip if the sender or recipient is the locker contract
+            if (sender == locker_address || recipient == locker_address) {
+                return;
+            }
+
+            assert(
+                amount <= self.total_supply().percent_mul(MAX_PERCENTAGE_BUY_LAUNCH.into()),
+                'Max buy cap reached'
+            )
+        }
     }
 }

--- a/contracts/src/utils/math.cairo
+++ b/contracts/src/utils/math.cairo
@@ -1,0 +1,11 @@
+const BPS: u256 = 10_000; // 100% = 10_000 bps
+
+trait PercentageMath {
+    fn percent_mul(self: u256, other: u256) -> u256;
+}
+
+impl PercentageMathImpl of PercentageMath {
+    fn percent_mul(self: u256, other: u256) -> u256 {
+        self * other / BPS
+    }
+}


### PR DESCRIPTION
1. Cleans the implementation of memecoin:
- Removes legacy code
- Apply clean code good practices
- Correctly separate different concerns in different functions
- Remove deadline parameter to supply to the AMM router (its in the same block anyway 😵 )

2. Make `transfer_limit_delay` a parameter upon launch

3. Clear tests from useless tests (e.g testing that transferFrom fails when allowance is too low)