### PR TITLE
refactor: clean memecoin tests and impl

### DIFF
--- a/contracts/src/amm/amm.cairo
+++ b/contracts/src/amm/amm.cairo
@@ -9,13 +9,15 @@ struct AMM {
 #[derive(Drop, Copy, Serde)]
 enum AMMV2 {
     JediSwap,
+    Ekubo // Unsupported
 }
 
 #[generate_trait]
 impl AMMImpl of AMMTrait {
     fn to_string(self: AMMV2) -> felt252 {
         match self {
-            AMMV2::JediSwap => 'JediSwap'
+            AMMV2::JediSwap => 'JediSwap',
+            AMMV2::Ekubo => 'Ekubo'
         }
     }
 }

--- a/contracts/src/tests/test_factory.cairo
+++ b/contracts/src/tests/test_factory.cairo
@@ -97,11 +97,18 @@ fn test_create_memecoin() {
     assert(memecoin.name() == NAME(), 'wrong memecoin name');
     assert(memecoin.symbol() == SYMBOL(), 'wrong memecoin symbol');
     // initial supply - initial holder balance
+    let holders_sum = *INITIAL_HOLDERS_AMOUNTS()[0] + *INITIAL_HOLDERS_AMOUNTS()[1];
     assert(
-        memecoin.balanceOf(memecoin_address) == DEFAULT_INITIAL_SUPPLY() - 100,
+        memecoin.balanceOf(memecoin_address) == DEFAULT_INITIAL_SUPPLY() - holders_sum,
         'wrong initial supply'
     );
-    assert(memecoin.balanceOf(*INITIAL_HOLDERS()[0]) == 50, 'wrong initial_holder_1 balance');
-    assert(memecoin.balanceOf(*INITIAL_HOLDERS()[1]) == 50, 'wrong initial_holder_2 balance');
+    assert(
+        memecoin.balanceOf(*INITIAL_HOLDERS()[0]) == *INITIAL_HOLDERS_AMOUNTS()[0],
+        'wrong initial_holder_1 balance'
+    );
+    assert(
+        memecoin.balanceOf(*INITIAL_HOLDERS()[1]) == *INITIAL_HOLDERS_AMOUNTS()[1],
+        'wrong initial_holder_2 balance'
+    );
 }
 

--- a/contracts/src/tests/test_memecoin_erc20.cairo
+++ b/contracts/src/tests/test_memecoin_erc20.cairo
@@ -7,174 +7,44 @@ use snforge_std::{
 };
 use starknet::{ContractAddress, contract_address_const};
 use unruggable::amm::amm::{AMM, AMMV2};
-use unruggable::tests::utils::{TxInfoMockTrait};
+use unruggable::tests::utils::{
+    OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, RECIPIENT, SPENDER, deploy_locker, INITIAL_HOLDERS,
+    INITIAL_HOLDERS_AMOUNTS, TRANSFER_LIMIT_DELAY, DefaultTxInfoMock, deploy_standalone_memecoin
+};
 use unruggable::tokens::interface::{
     IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
 };
 
-//
-// Constants
-//
-
-fn RECIPIENT() -> ContractAddress {
-    return contract_address_const::<'RECIPIENT'>();
-}
-
-fn SPENDER() -> ContractAddress {
-    return contract_address_const::<'RECIPIENT'>();
-}
-
-const ETH_UNIT_DECIMALS: u256 = 1000000000000000000;
-
-//
-// Setup
-//
-
-fn deploy_contract(
-    owner: ContractAddress,
-    name: felt252,
-    symbol: felt252,
-    initial_supply: u256,
-    initial_holders: Span<ContractAddress>,
-    initial_holders_amounts: Span<u256>,
-) -> Result<ContractAddress, RevertedTransaction> {
-    let contract = declare('UnruggableMemecoin');
-    let mut constructor_calldata = array![
-        owner.into(),
-        'locker',
-        1000.into(),
-        name,
-        symbol,
-        initial_supply.low.into(),
-        initial_supply.high.into()
-    ];
-
-    Serde::serialize(@initial_holders.into(), ref constructor_calldata);
-    Serde::serialize(@initial_holders_amounts.into(), ref constructor_calldata);
-    contract.deploy(@constructor_calldata)
-}
-
-fn instantiate_params() -> (
-    ContractAddress,
-    felt252,
-    felt252,
-    u256,
-    ContractAddress,
-    ContractAddress,
-    Span<ContractAddress>,
-    Span<u256>,
-) {
-    let owner = contract_address_const::<42>();
-    let name = 'UnruggableMemecoin';
-    let symbol = 'UM';
-    let initial_supply = 1000;
-    let initial_holder_1 = contract_address_const::<44>();
-    let initial_holder_2 = contract_address_const::<45>();
-    let initial_holders = array![initial_holder_1, initial_holder_2].span();
-    let initial_holders_amounts = array![50, 50].span();
-    (
-        owner,
-        name,
-        symbol,
-        initial_supply,
-        initial_holder_1,
-        initial_holder_2,
-        initial_holders,
-        initial_holders_amounts
-    )
-}
 
 mod erc20_metadata {
     use core::debug::PrintTrait;
     use openzeppelin::token::erc20::interface::IERC20;
     use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank, CheatTarget};
     use starknet::{ContractAddress, contract_address_const};
-    use super::{deploy_contract, instantiate_params};
+    use super::{
+        deploy_standalone_memecoin, OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, RECIPIENT, SPENDER,
+        deploy_locker, TRANSFER_LIMIT_DELAY
+    };
     use unruggable::tokens::interface::{
         IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
     };
 
     #[test]
     fn test_name() {
-        let (
-            owner,
-            name,
-            symbol,
-            initial_supply,
-            initial_holder_1,
-            initial_holder_2,
-            initial_holders,
-            initial_holders_amounts
-        ) =
-            instantiate_params();
-        let contract_address =
-            match deploy_contract(
-                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-            ) {
-            Result::Ok(address) => address,
-            Result::Err(msg) => panic(msg.panic_data),
-        };
-
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
-
-        // Check name. Should be equal to 'UnruggableMemecoin'.
-        let name = memecoin.name();
-        assert(name == 'UnruggableMemecoin', 'Invalid name');
+        let (memecoin, memecoin_address) = deploy_standalone_memecoin();
+        assert(memecoin.name() == NAME(), 'Invalid name');
     }
 
     #[test]
     fn test_decimals() {
-        let (
-            owner,
-            name,
-            symbol,
-            initial_supply,
-            initial_holder_1,
-            initial_holder_2,
-            initial_holders,
-            initial_holders_amounts
-        ) =
-            instantiate_params();
-        let contract_address =
-            match deploy_contract(
-                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-            ) {
-            Result::Ok(address) => address,
-            Result::Err(msg) => panic(msg.panic_data),
-        };
-
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
-
-        // Check decimals. Should be equal to 18.
-        let decimals = memecoin.decimals();
-        assert(decimals == 18, 'Invalid decimals');
+        let (memecoin, memecoin_address) = deploy_standalone_memecoin();
+        assert(memecoin.decimals() == 18, 'Invalid decimals');
     }
 
     #[test]
     fn test_symbol() {
-        let (
-            owner,
-            name,
-            symbol,
-            initial_supply,
-            initial_holder_1,
-            initial_holder_2,
-            initial_holders,
-            initial_holders_amounts
-        ) =
-            instantiate_params();
-        let contract_address =
-            match deploy_contract(
-                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-            ) {
-            Result::Ok(address) => address,
-            Result::Err(msg) => panic(msg.panic_data),
-        };
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
-
-        // Check symbol. Should be equal to 'UM'.
-        let symbol = memecoin.symbol();
-        assert(symbol == symbol, 'Invalid symbol');
+        let (memecoin, memecoin_address) = deploy_standalone_memecoin();
+        assert(memecoin.symbol() == SYMBOL(), 'Invalid symbol');
     }
 }
 
@@ -182,16 +52,15 @@ mod erc20_entrypoints {
     use core::array::SpanTrait;
     use core::debug::PrintTrait;
     use core::traits::Into;
-    use openzeppelin::token::erc20::interface::IERC20;
     use snforge_std::{
         declare, ContractClassTrait, start_prank, stop_prank, start_warp, CheatTarget, TxInfoMock
     };
     use starknet::{ContractAddress, contract_address_const};
-    use super::{deploy_contract, instantiate_params};
-    use unruggable::tests::utils::DeployerHelper::{
-        deploy_contracts, deploy_unruggable_memecoin_contract, deploy_memecoin_factory, create_eth
+    use super::{
+        deploy_standalone_memecoin, OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, RECIPIENT, SPENDER,
+        deploy_locker, TRANSFER_LIMIT_DELAY, INITIAL_HOLDERS, DefaultTxInfoMock,
+        INITIAL_HOLDERS_AMOUNTS
     };
-    use unruggable::tests::utils::{DefaultTxInfoMock};
     use unruggable::tokens::interface::{
         IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
     };
@@ -200,316 +69,142 @@ mod erc20_entrypoints {
 
     #[test]
     fn test_total_supply() {
-        let (
-            owner,
-            name,
-            symbol,
-            initial_supply,
-            initial_holder_1,
-            initial_holder_2,
-            initial_holders,
-            initial_holders_amounts
-        ) =
-            instantiate_params();
-        let contract_address =
-            match deploy_contract(
-                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-            ) {
-            Result::Ok(address) => address,
-            Result::Err(msg) => panic(msg.panic_data),
-        };
-
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
-
-        // Check total supply. Should be equal to initial supply.
-        let total_supply = memecoin.total_supply();
-        assert(total_supply == initial_supply, 'Invalid total supply');
+        let (memecoin, memecoin_address) = deploy_standalone_memecoin();
+        assert(memecoin.total_supply() == DEFAULT_INITIAL_SUPPLY(), 'Invalid total supply');
     }
 
     #[test]
     fn test_balance_of() {
-        let (
-            owner,
-            name,
-            symbol,
-            initial_supply,
-            initial_holder_1,
-            initial_holder_2,
-            initial_holders,
-            initial_holders_amounts
-        ) =
-            instantiate_params();
-        let contract_address =
-            match deploy_contract(
-                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-            ) {
-            Result::Ok(address) => address,
-            Result::Err(msg) => panic(msg.panic_data),
-        };
+        let (memecoin, memecoin_address) = deploy_standalone_memecoin();
+        let holders_sum = *INITIAL_HOLDERS_AMOUNTS()[0] + *INITIAL_HOLDERS_AMOUNTS()[1];
 
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
-
-        // Check initial contract balance. Should be equal to 900.
-        let balance = memecoin.balance_of(contract_address);
-        assert(balance == 900, 'Invalid balance');
-        // Check initial holder 1 balance. Should be equal to 50.
-        let balance = memecoin.balance_of(initial_holder_1);
-        assert(balance == 50, 'Invalid balance');
-        // Check initial holder 2 balance. Should be equal to 50.
-        let balance = memecoin.balance_of(initial_holder_1);
-        assert(balance == 50, 'Invalid balance');
+        // Check initial contract balance and initial holders balances.
+        assert(
+            memecoin.balance_of(memecoin_address) == DEFAULT_INITIAL_SUPPLY() - holders_sum,
+            'Invalid balance memecoin'
+        );
+        assert(
+            memecoin.balance_of(*INITIAL_HOLDERS()[0]) == *INITIAL_HOLDERS_AMOUNTS()[0],
+            'Invalid balance holder1'
+        );
+        assert(
+            memecoin.balance_of(*INITIAL_HOLDERS()[1]) == *INITIAL_HOLDERS_AMOUNTS()[1],
+            'Invalid balance holder2'
+        );
     }
 
     #[test]
     fn test_approve_allowance() {
-        let (
-            owner,
-            name,
-            symbol,
-            initial_supply,
-            initial_holder_1,
-            initial_holder_2,
-            initial_holders,
-            initial_holders_amounts
-        ) =
-            instantiate_params();
-        let spender = super::SPENDER();
-        let contract_address =
-            match deploy_contract(
-                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-            ) {
-            Result::Ok(address) => address,
-            Result::Err(msg) => panic(msg.panic_data),
-        };
-
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
+        let (memecoin, memecoin_address) = deploy_standalone_memecoin();
 
         // Check initial allowance. Should be equal to 0.
-        let allowance = memecoin.allowance(owner, spender);
+        let allowance = memecoin.allowance(OWNER(), SPENDER());
         assert(allowance == 0, 'Invalid allowance before');
 
         // Approve initial supply tokens.
-        start_prank(CheatTarget::One(memecoin.contract_address), owner);
-        memecoin.approve(spender, initial_supply);
+        start_prank(CheatTarget::One(memecoin.contract_address), OWNER());
+        memecoin.approve(SPENDER(), DEFAULT_INITIAL_SUPPLY());
 
         // Check allowance. Should be equal to initial supply.
-        let allowance = memecoin.allowance(owner, spender);
-        assert(allowance == initial_supply, 'Invalid allowance after');
+        let allowance = memecoin.allowance(OWNER(), SPENDER());
+        assert(allowance == DEFAULT_INITIAL_SUPPLY(), 'Invalid allowance after');
     }
 
     #[test]
     fn test_transfer() {
-        let (
-            owner,
-            name,
-            symbol,
-            initial_supply,
-            initial_holder_1,
-            initial_holder_2,
-            initial_holders,
-            initial_holders_amounts
-        ) =
-            instantiate_params();
-        let recipient = super::RECIPIENT();
-        let contract_address =
-            match deploy_contract(
-                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-            ) {
-            Result::Ok(address) => address,
-            Result::Err(msg) => panic(msg.panic_data),
-        };
-
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
-
-        // setting tx_hash here 
-        let mut tx_info: TxInfoMock = Default::default();
-        tx_info.transaction_hash = Option::Some(1234);
-        snforge_std::start_spoof(CheatTarget::One(memecoin.contract_address), tx_info);
+        let (memecoin, memecoin_address) = deploy_standalone_memecoin();
 
         // Transfer 20 tokens to recipient.
-        start_prank(CheatTarget::One(memecoin.contract_address), initial_holder_1);
-        memecoin.transfer(recipient, 20);
+        let pre_sender_balance = memecoin.balance_of(*INITIAL_HOLDERS()[0]);
+        start_prank(CheatTarget::One(memecoin.contract_address), *INITIAL_HOLDERS()[0]);
+        memecoin.transfer(RECIPIENT(), 20);
 
         // Check balance. Should be equal to initial balance - 20.
-        let initial_holder_1_balance = memecoin.balance_of(initial_holder_1);
-        assert(initial_holder_1_balance == 50 - 20, 'Invalid balance holder 1');
+        let post_sender_balance = memecoin.balance_of(*INITIAL_HOLDERS()[0]);
+        assert(post_sender_balance == pre_sender_balance - 20, 'Invalid sender balance update');
 
         // Check recipient balance. Should be equal to 20.
-        let recipient_balance = memecoin.balance_of(recipient);
+        let recipient_balance = memecoin.balance_of(RECIPIENT());
         assert(recipient_balance == 20, 'Invalid balance recipient');
     }
 
     #[test]
     fn test_transfer_from() {
-        let (
-            owner,
-            name,
-            symbol,
-            initial_supply,
-            initial_holder_1,
-            initial_holder_2,
-            initial_holders,
-            initial_holders_amounts
-        ) =
-            instantiate_params();
-        let spender = super::SPENDER();
-        let recipient = super::RECIPIENT();
-        let contract_address =
-            match deploy_contract(
-                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-            ) {
-            Result::Ok(address) => address,
-            Result::Err(msg) => panic(msg.panic_data),
-        };
-
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
-
-        // Check initial balance. Should be equal to 50.
-        let balance = memecoin.balance_of(initial_holder_1);
-        assert(balance == 50, 'Invalid balance');
+        let (memecoin, memecoin_address) = deploy_standalone_memecoin();
+        let pre_sender_balance = memecoin.balance_of(*INITIAL_HOLDERS()[0]);
 
         // Approve initial supply tokens.
-        start_prank(CheatTarget::One(memecoin.contract_address), initial_holder_1);
-        memecoin.approve(spender, initial_supply);
-
-        // setting tx_hash here 
-        let mut tx_info: TxInfoMock = Default::default();
-        tx_info.transaction_hash = Option::Some(1234);
-        snforge_std::start_spoof(CheatTarget::One(memecoin.contract_address), tx_info);
+        start_prank(CheatTarget::One(memecoin.contract_address), *INITIAL_HOLDERS()[0]);
+        memecoin.approve(SPENDER(), DEFAULT_INITIAL_SUPPLY());
 
         // Transfer 20 tokens to recipient.
-        start_prank(CheatTarget::One(memecoin.contract_address), spender);
-        memecoin.transfer_from(initial_holder_1, recipient, 20);
+        start_prank(CheatTarget::One(memecoin.contract_address), SPENDER());
+        memecoin.transfer_from(*INITIAL_HOLDERS()[0], RECIPIENT(), 20);
 
         // Check balance. Should be equal to initial balance - 20.
-        let initial_holder_1_balance = memecoin.balance_of(initial_holder_1);
-        assert(initial_holder_1_balance == 50 - 20, 'Invalid balance holder 1');
+        let post_sender_balance = memecoin.balance_of(*INITIAL_HOLDERS()[0]);
+        assert(post_sender_balance == pre_sender_balance - 20, 'Invalid sender balance update');
 
         // Check recipient balance. Should be equal to 20.
-        let recipient_balance = memecoin.balance_of(recipient);
+        let recipient_balance = memecoin.balanceOf(RECIPIENT());
         assert(recipient_balance == 20, 'Invalid balance recipient');
 
         // Check allowance. Should be equal to initial supply - transfered amount.
-        let allowance = memecoin.allowance(initial_holder_1, spender);
-        assert(allowance == (initial_supply - 20), 'Invalid allowance');
+        let allowance = memecoin.allowance(*INITIAL_HOLDERS()[0], SPENDER());
+        assert(allowance == (DEFAULT_INITIAL_SUPPLY() - 20), 'Invalid allowance');
     }
 
     // Test ERC20 Camel entrypoints
 
     #[test]
     fn test_totalSupply() {
-        let (
-            owner,
-            name,
-            symbol,
-            initial_supply,
-            initial_holder_1,
-            initial_holder_2,
-            initial_holders,
-            initial_holders_amounts
-        ) =
-            instantiate_params();
-        let contract_address =
-            match deploy_contract(
-                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-            ) {
-            Result::Ok(address) => address,
-            Result::Err(msg) => panic(msg.panic_data),
-        };
-
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
-
-        // Check total supply. Should be equal to initial supply.
-        let total_supply = memecoin.totalSupply();
-        assert(total_supply == initial_supply, 'Invalid total supply');
+        let (memecoin, memecoin_address) = deploy_standalone_memecoin();
+        assert(memecoin.totalSupply() == DEFAULT_INITIAL_SUPPLY(), 'Invalid total supply');
     }
 
     #[test]
     fn test_balanceOf() {
-        let (
-            owner,
-            name,
-            symbol,
-            initial_supply,
-            initial_holder_1,
-            initial_holder_2,
-            initial_holders,
-            initial_holders_amounts
-        ) =
-            instantiate_params();
-        let contract_address =
-            match deploy_contract(
-                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-            ) {
-            Result::Ok(address) => address,
-            Result::Err(msg) => panic(msg.panic_data),
-        };
+        let (memecoin, memecoin_address) = deploy_standalone_memecoin();
+        let holders_sum = *INITIAL_HOLDERS_AMOUNTS()[0] + *INITIAL_HOLDERS_AMOUNTS()[1];
 
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
-
-        // Check initial contract balance. Should be equal to 900.
-        let balance = memecoin.balanceOf(contract_address);
-        assert(balance == 900, 'Invalid balance');
-        // Check initial holder 1 balance. Should be equal to 50.
-        let balance = memecoin.balanceOf(initial_holder_1);
-        assert(balance == 50, 'Invalid balance');
-        // Check initial holder 2 balance. Should be equal to 50.
-        let balance = memecoin.balanceOf(initial_holder_1);
-        assert(balance == 50, 'Invalid balance');
+        // Check initial contract balance and initial holders balances.
+        assert(
+            memecoin.balanceOf(memecoin_address) == DEFAULT_INITIAL_SUPPLY() - holders_sum,
+            'Invalid balance memecoin'
+        );
+        assert(
+            memecoin.balance_of(*INITIAL_HOLDERS()[0]) == *INITIAL_HOLDERS_AMOUNTS()[0],
+            'Invalid balance holder1'
+        );
+        assert(
+            memecoin.balance_of(*INITIAL_HOLDERS()[1]) == *INITIAL_HOLDERS_AMOUNTS()[1],
+            'Invalid balance holder2'
+        );
     }
 
     #[test]
     fn test_transferFrom() {
-        let (
-            owner,
-            name,
-            symbol,
-            initial_supply,
-            initial_holder_1,
-            initial_holder_2,
-            initial_holders,
-            initial_holders_amounts
-        ) =
-            instantiate_params();
-        let spender = super::SPENDER();
-        let recipient = super::RECIPIENT();
-        let contract_address =
-            match deploy_contract(
-                owner, name, symbol, initial_supply, initial_holders, initial_holders_amounts
-            ) {
-            Result::Ok(address) => address,
-            Result::Err(msg) => panic(msg.panic_data),
-        };
-
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address };
-
-        // Check initial balance. Should be equal to 50.
-        let balance = memecoin.balance_of(initial_holder_1);
-        assert(balance == 50, 'Invalid balance');
+        let (memecoin, memecoin_address) = deploy_standalone_memecoin();
+        let pre_sender_balance = memecoin.balance_of(*INITIAL_HOLDERS()[0]);
 
         // Approve initial supply tokens.
-        start_prank(CheatTarget::One(memecoin.contract_address), initial_holder_1);
-        memecoin.approve(spender, initial_supply);
-
-        // setting tx_hash here 
-        let mut tx_info: TxInfoMock = Default::default();
-        tx_info.transaction_hash = Option::Some(1234);
-        snforge_std::start_spoof(CheatTarget::One(memecoin.contract_address), tx_info);
+        start_prank(CheatTarget::One(memecoin.contract_address), *INITIAL_HOLDERS()[0]);
+        memecoin.approve(SPENDER(), DEFAULT_INITIAL_SUPPLY());
 
         // Transfer 20 tokens to recipient.
-        start_prank(CheatTarget::One(memecoin.contract_address), spender);
-        memecoin.transferFrom(initial_holder_1, recipient, 20);
+        start_prank(CheatTarget::One(memecoin.contract_address), SPENDER());
+        memecoin.transferFrom(*INITIAL_HOLDERS()[0], RECIPIENT(), 20);
 
         // Check balance. Should be equal to initial balance - 20.
-        let initial_holder_1_balance = memecoin.balance_of(initial_holder_1);
-        assert(initial_holder_1_balance == 50 - 20, 'Invalid balance holder 1');
+        let post_sender_balance = memecoin.balance_of(*INITIAL_HOLDERS()[0]);
+        assert(post_sender_balance == pre_sender_balance - 20, 'Invalid sender balance update');
 
         // Check recipient balance. Should be equal to 20.
-        let recipient_balance = memecoin.balance_of(recipient);
+        let recipient_balance = memecoin.balanceOf(RECIPIENT());
         assert(recipient_balance == 20, 'Invalid balance recipient');
 
         // Check allowance. Should be equal to initial supply - transfered amount.
-        let allowance = memecoin.allowance(initial_holder_1, spender);
-        assert(allowance == (initial_supply - 20), 'Invalid allowance');
+        let allowance = memecoin.allowance(*INITIAL_HOLDERS()[0], SPENDER());
+        assert(allowance == (DEFAULT_INITIAL_SUPPLY() - 20), 'Invalid allowance');
     }
 }

--- a/contracts/src/tests/utils.cairo
+++ b/contracts/src/tests/utils.cairo
@@ -7,10 +7,30 @@ use snforge_std::{
 use starknet::ContractAddress;
 use unruggable::amm::amm::{AMM, AMMV2, AMMTrait};
 use unruggable::factory::{IFactoryDispatcher, IFactoryDispatcherTrait};
+use unruggable::tokens::interface::{
+    IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
+};
+
 
 // Constants
 fn OWNER() -> ContractAddress {
     'owner'.try_into().unwrap()
+}
+
+fn RECIPIENT() -> ContractAddress {
+    'recipient'.try_into().unwrap()
+}
+
+fn SPENDER() -> ContractAddress {
+    'spender'.try_into().unwrap()
+}
+
+fn ALICE() -> ContractAddress {
+    'alice'.try_into().unwrap()
+}
+
+fn BOB() -> ContractAddress {
+    'bob'.try_into().unwrap()
 }
 
 fn NAME() -> felt252 {
@@ -29,13 +49,13 @@ fn INITIAL_HOLDER_2() -> ContractAddress {
     'initial_holder_2'.try_into().unwrap()
 }
 
-
 fn INITIAL_HOLDERS() -> Span<ContractAddress> {
     array![INITIAL_HOLDER_1(), INITIAL_HOLDER_2()].span()
 }
 
+// Hold 5% of the supply each - reaching 10% of the supply, the maximum allowed
 fn INITIAL_HOLDERS_AMOUNTS() -> Span<u256> {
-    array![50, 50].span()
+    array![1_050_000 * pow_256(10, 18), 1_050_000 * pow_256(10, 18)].span()
 }
 
 fn DEPLOYER() -> ContractAddress {
@@ -50,24 +70,17 @@ fn DEFAULT_INITIAL_SUPPLY() -> u256 {
     21_000_000 * pow_256(10, 18)
 }
 
-
-trait TxInfoMockTrait {
-    fn default() -> TxInfoMock;
+fn ETH_INITIAL_SUPPLY() -> u256 {
+    2 * pow_256(10, ETH_DECIMALS)
 }
 
-impl DefaultTxInfoMock of Default<TxInfoMock> {
-    fn default() -> TxInfoMock {
-        TxInfoMock {
-            version: Option::None,
-            account_contract_address: Option::None,
-            max_fee: Option::None,
-            signature: Option::None,
-            transaction_hash: Option::None,
-            chain_id: Option::None,
-            nonce: Option::None,
-        }
-    }
+fn LOCKER_ADDRESS() -> ContractAddress {
+    'locker'.try_into().unwrap()
 }
+
+
+const ETH_DECIMALS: u8 = 18;
+const TRANSFER_LIMIT_DELAY: u64 = 1000;
 
 
 // NOT THE ACTUAL ETH ADDRESS
@@ -77,11 +90,50 @@ fn ETH_ADDRESS() -> ContractAddress {
     0x7fff6570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7.try_into().unwrap()
 }
 
+fn JEDI_ROUTER_ADDRESS() -> ContractAddress {
+    'router_address'.try_into().unwrap()
+}
+
+fn JEDI_FACTORY_ADDRESS() -> ContractAddress {
+    'jediswap factory'.try_into().unwrap()
+}
+
+
+fn MEMEFACTORY_ADDRESS() -> ContractAddress {
+    'memefactory_address'.try_into().unwrap()
+}
+
 fn DEFAULT_MIN_LOCKTIME() -> u64 {
     200
 }
 
 // Deployments
+
+// Deploys a simple instance of the memcoin to test ERC20 basic entrypoints.
+fn deploy_standalone_memecoin() -> (IUnruggableMemecoinDispatcher, ContractAddress) {
+    // Deploy the locker associated with the memecoin.
+    let locker = deploy_locker();
+
+    // Deploy the memecoin with the default parameters.
+    let contract = declare('UnruggableMemecoin');
+    let mut calldata = array![
+        OWNER().into(), locker.into(), TRANSFER_LIMIT_DELAY.into(), NAME().into(), SYMBOL().into(),
+    ];
+    Serde::serialize(@DEFAULT_INITIAL_SUPPLY(), ref calldata);
+    Serde::serialize(@INITIAL_HOLDERS(), ref calldata);
+    Serde::serialize(@INITIAL_HOLDERS_AMOUNTS(), ref calldata);
+    let contract_address = contract.deploy(@calldata).expect('failed to deploy memecoin');
+    let memecoin = IUnruggableMemecoinDispatcher { contract_address };
+
+    // Set the transaction_hash to an arbitrary value - used to test the
+    // multicall buy prevention feature.
+    let mut tx_info: TxInfoMock = Default::default();
+    tx_info.transaction_hash = Option::Some(1234);
+    snforge_std::start_spoof(CheatTarget::One(memecoin.contract_address), tx_info);
+
+    (memecoin, contract_address)
+}
+
 
 // AMM
 
@@ -94,7 +146,9 @@ fn deploy_amm_factory() -> ContractAddress {
     Serde::serialize(@DEPLOYER(), ref constructor_calldata);
     let factory_class = declare('FactoryC1');
 
-    let factory_address = factory_class.deploy(@constructor_calldata).unwrap();
+    let factory_address = factory_class
+        .deploy_at(@constructor_calldata, JEDI_FACTORY_ADDRESS())
+        .unwrap();
 
     factory_address
 }
@@ -105,7 +159,9 @@ fn deploy_router(factory_address: ContractAddress) -> ContractAddress {
     let mut router_constructor_calldata = Default::default();
     Serde::serialize(@factory_address, ref router_constructor_calldata);
 
-    let amm_router_address = amm_router_class.deploy(@router_constructor_calldata).unwrap();
+    let amm_router_address = amm_router_class
+        .deploy_at(@router_constructor_calldata, JEDI_ROUTER_ADDRESS())
+        .unwrap();
 
     amm_router_address
 }
@@ -129,7 +185,7 @@ fn deploy_meme_factory(router_address: ContractAddress) -> ContractAddress {
     Serde::serialize(@OWNER(), ref calldata);
     Serde::serialize(@memecoin_class_hash, ref calldata);
     Serde::serialize(@amms.into(), ref calldata);
-    contract.deploy(@calldata).expect('UnrugFactory deployment failed')
+    contract.deploy_at(@calldata, MEMEFACTORY_ADDRESS()).expect('UnrugFactory deployment failed')
 }
 
 fn deploy_meme_factory_with_owner(
@@ -154,16 +210,10 @@ fn deploy_locker() -> ContractAddress {
     let mut calldata = Default::default();
     Serde::serialize(@DEFAULT_MIN_LOCKTIME(), ref calldata);
     let locker_contract = declare('TokenLocker');
-    locker_contract.deploy(@calldata).expect('Locker deployment failed')
+    locker_contract.deploy_at(@calldata, LOCKER_ADDRESS()).expect('Locker deployment failed')
 }
 
 // ETH Token
-
-const ETH_DECIMALS: u8 = 18;
-
-fn ETH_INITIAL_SUPPLY() -> u256 {
-    2 * pow_256(10, ETH_DECIMALS)
-}
 
 fn deploy_eth() -> (ERC20ABIDispatcher, ContractAddress) {
     deploy_eth_with_owner(OWNER())
@@ -182,37 +232,68 @@ fn deploy_eth_with_owner(owner: ContractAddress) -> (ERC20ABIDispatcher, Contrac
 
 // Memercoin
 
-fn deploy_memecoin() -> ContractAddress {
+fn deploy_memecoin_through_factory_with_owner(
+    owner: ContractAddress
+) -> (IUnruggableMemecoinDispatcher, ContractAddress) {
     // Required contracts
     let (_, router_address) = deploy_amm_factory_and_router();
     let memecoin_factory_address = deploy_meme_factory(router_address);
     let memecoin_factory = IFactoryDispatcher { contract_address: memecoin_factory_address };
     let locker_address = deploy_locker();
-    let (eth, eth_address) = deploy_eth();
+    let (eth, eth_address) = deploy_eth_with_owner(owner);
 
     let eth_amount: u256 = eth.total_supply() / 2; // 50% of supply
 
-    start_prank(CheatTarget::One(eth.contract_address), OWNER());
+    start_prank(CheatTarget::One(eth.contract_address), owner);
     eth.approve(memecoin_factory_address, eth_amount);
     stop_prank(CheatTarget::One(eth.contract_address));
 
-    start_prank(CheatTarget::One(memecoin_factory.contract_address), OWNER());
+    start_prank(CheatTarget::One(memecoin_factory.contract_address), owner);
     let memecoin_address = memecoin_factory
         .create_memecoin(
-            owner: OWNER(),
+            owner: owner,
             :locker_address,
             name: NAME(),
             symbol: SYMBOL(),
             initial_supply: DEFAULT_INITIAL_SUPPLY(),
             initial_holders: INITIAL_HOLDERS(),
             initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
-            transfer_limit_delay: 1000,
+            transfer_limit_delay: TRANSFER_LIMIT_DELAY,
             counterparty_token: eth,
             contract_address_salt: SALT(),
         );
     stop_prank(CheatTarget::One(memecoin_factory.contract_address));
-    memecoin_address
+
+    // Upon deployment, we mock the transaction_hash of the current tx.
+    // This is because for each tx, we check during transfers whether a transfer already
+    // occured in the same tx. Rather than adding these lines in each test, we make it a default.
+    let mut tx_info: TxInfoMock = Default::default();
+    tx_info.transaction_hash = Option::Some(1234);
+    snforge_std::start_spoof(CheatTarget::One(memecoin_address), tx_info);
+
+    (IUnruggableMemecoinDispatcher { contract_address: memecoin_address }, memecoin_address)
 }
+
+
+fn deploy_memecoin_through_factory() -> (IUnruggableMemecoinDispatcher, ContractAddress) {
+    deploy_memecoin_through_factory_with_owner(OWNER())
+}
+
+
+impl DefaultTxInfoMock of Default<TxInfoMock> {
+    fn default() -> TxInfoMock {
+        TxInfoMock {
+            version: Option::None,
+            account_contract_address: Option::None,
+            max_fee: Option::None,
+            signature: Option::None,
+            transaction_hash: Option::None,
+            chain_id: Option::None,
+            nonce: Option::None,
+        }
+    }
+}
+
 
 // Math
 fn pow_256(self: u256, mut exponent: u8) -> u256 {
@@ -233,99 +314,5 @@ fn pow_256(self: u256, mut exponent: u8) -> u256 {
         }
 
         base = base * base;
-    }
-}
-
-//TODO: legacy, remove later
-mod DeployerHelper {
-    use openzeppelin::token::erc20::interface::{
-        IERC20, ERC20ABIDispatcher, ERC20ABIDispatcherTrait
-    };
-    use snforge_std::{
-        ContractClass, ContractClassTrait, CheatTarget, declare, start_prank, stop_prank
-    };
-    use starknet::{ContractAddress, ClassHash, contract_address_const};
-    use unruggable::amm::amm::AMM;
-
-    const ETH_UNIT_DECIMALS: u256 = 1000000000000000000;
-
-    fn deploy_contracts() -> (ContractAddress, ContractAddress) {
-        let deployer = contract_address_const::<'DEPLOYER'>();
-        let pair_class = declare('PairC1');
-
-        let mut factory_constructor_calldata = Default::default();
-
-        Serde::serialize(@pair_class.class_hash, ref factory_constructor_calldata);
-        Serde::serialize(@deployer, ref factory_constructor_calldata);
-        let factory_class = declare('FactoryC1');
-
-        let factory_address = factory_class.deploy(@factory_constructor_calldata).unwrap();
-
-        let mut router_constructor_calldata = Default::default();
-        Serde::serialize(@factory_address, ref router_constructor_calldata);
-        let router_class = declare('RouterC1');
-
-        let router_address = router_class.deploy(@router_constructor_calldata).unwrap();
-
-        (factory_address, router_address)
-    }
-
-    fn deploy_unruggable_memecoin_contract(
-        owner: ContractAddress,
-        recipient: ContractAddress,
-        name: felt252,
-        symbol: felt252,
-        initial_supply: u256,
-        amms: Array<AMM>
-    ) -> ContractAddress {
-        let contract = declare('UnruggableMemecoin');
-        let mut constructor_calldata = array![
-            owner.into(),
-            recipient.into(),
-            name,
-            symbol,
-            initial_supply.low.into(),
-            initial_supply.high.into(),
-        ];
-        contract.deploy(@constructor_calldata).unwrap()
-    }
-
-    fn deploy_memecoin_factory(
-        owner: ContractAddress, memecoin_class_hash: ClassHash, amms: Array<AMM>
-    ) -> ContractAddress {
-        let contract = declare('Factory');
-        let mut calldata = array![];
-        calldata.append(owner.into());
-        calldata.append(memecoin_class_hash.into());
-        Serde::serialize(@amms.into(), ref calldata);
-
-        contract.deploy(@calldata).unwrap()
-    }
-
-    fn create_eth(
-        initial_supply: u256, owner: ContractAddress, factory: ContractAddress
-    ) -> ERC20ABIDispatcher {
-        let erc20_token = declare('ERC20Token');
-        let eth_amount: u256 = initial_supply;
-        let erc20_calldata: Array<felt252> = array![
-            eth_amount.low.into(), eth_amount.high.into(), owner.into()
-        ];
-        let eth_address = erc20_token
-            .deploy_at(
-                @erc20_calldata,
-                contract_address_const::<
-                    0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                >()
-            )
-            .unwrap();
-        let eth = ERC20ABIDispatcher { contract_address: eth_address };
-        assert(eth.balanceOf(owner) == initial_supply, 'wrong eth balance');
-        start_prank(CheatTarget::One(eth.contract_address), owner);
-        eth.approve(spender: factory, amount: 1 * ETH_UNIT_DECIMALS);
-        stop_prank(CheatTarget::One(eth.contract_address));
-        assert(
-            eth.allowance(:owner, spender: factory) == 1 * ETH_UNIT_DECIMALS, 'wrong eth allowance'
-        );
-        eth
     }
 }

--- a/contracts/src/tokens/interface.cairo
+++ b/contracts/src/tokens/interface.cairo
@@ -5,6 +5,13 @@ use unruggable::amm::amm::AMMV2;
 #[starknet::interface]
 trait IUnruggableMemecoin<TState> {
     // ************************************
+    // * Ownership
+    // ************************************
+    fn owner(self: @TState) -> ContractAddress;
+    fn transfer_ownership(ref self: TState, new_owner: ContractAddress);
+    fn renounce_ownership(ref self: TState);
+
+    // ************************************
     // * Metadata
     // ************************************
     fn name(self: @TState) -> felt252;
@@ -44,6 +51,8 @@ trait IUnruggableMemecoin<TState> {
         ref self: TState, amm_v2: AMMV2, counterparty_token_address: ContractAddress,
     ) -> ContractAddress;
     fn get_team_allocation(self: @TState) -> u256;
+    fn memecoin_factory_address(self: @TState) -> ContractAddress;
+    fn locker_address(self: @TState) -> ContractAddress;
 }
 
 #[starknet::interface]
@@ -78,4 +87,6 @@ trait IUnruggableAdditional<TState> {
         ref self: TState, amm_v2: AMMV2, counterparty_token_address: ContractAddress,
     ) -> ContractAddress;
     fn get_team_allocation(self: @TState) -> u256;
+    fn memecoin_factory_address(self: @TState) -> ContractAddress;
+    fn locker_address(self: @TState) -> ContractAddress;
 }


### PR DESCRIPTION
- use constant values for deployment test addresses
- use constant values for deployment variables
- clean deployment utils
- clean tests to use reusable deployment logic
- add ownership entrypoints to memecoin
- add entrypoints to get locker and factory addresses

This should be merged after #105 as it depends on it (and once 105 is merged, the base branch should be changed to main)