### PR TITLE
Setup Transfer restriction delay at launch

### DIFF
--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -104,9 +104,7 @@ mod Factory {
             initial_holders_amounts: Span<u256>,
             contract_address_salt: felt252,
         ) -> ContractAddress {
-            let mut calldata = array![
-                owner.into(), name.into(), symbol.into()
-            ];
+            let mut calldata = array![owner.into(), name.into(), symbol.into()];
             Serde::serialize(@initial_supply, ref calldata);
             Serde::serialize(@initial_holders.into(), ref calldata);
             Serde::serialize(@initial_holders_amounts.into(), ref calldata);

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -102,11 +102,10 @@ mod Factory {
             initial_supply: u256,
             initial_holders: Span<ContractAddress>,
             initial_holders_amounts: Span<u256>,
-            transfer_limit_delay: u64,
             contract_address_salt: felt252,
         ) -> ContractAddress {
             let mut calldata = array![
-                owner.into(), transfer_limit_delay.into(), name.into(), symbol.into()
+                owner.into(), name.into(), symbol.into()
             ];
             Serde::serialize(@initial_supply, ref calldata);
             Serde::serialize(@initial_holders.into(), ref calldata);
@@ -128,6 +127,7 @@ mod Factory {
         fn launch_on_jediswap(
             ref self: ContractState,
             memecoin_address: ContractAddress,
+            transfer_restriction_delay: u64,
             quote_address: ContractAddress,
             quote_amount: u256,
             unlock_time: u64,
@@ -152,7 +152,7 @@ mod Factory {
                 }
             );
 
-            memecoin.set_launched(LiquidityType::ERC20(pair_address));
+            memecoin.set_launched(LiquidityType::ERC20(pair_address), :transfer_restriction_delay);
             self
                 .emit(
                     MemecoinLaunched {
@@ -165,6 +165,7 @@ mod Factory {
         fn launch_on_ekubo(
             ref self: ContractState,
             memecoin_address: ContractAddress,
+            transfer_restriction_delay: u64,
             quote_address: ContractAddress,
             ekubo_parameters: EkuboPoolParameters,
         ) -> (u64, EkuboLP) {
@@ -184,7 +185,7 @@ mod Factory {
                 additional_parameters: ekubo_parameters
             );
 
-            memecoin.set_launched(LiquidityType::NFT(id));
+            memecoin.set_launched(LiquidityType::NFT(id), :transfer_restriction_delay);
             self
                 .emit(
                     MemecoinLaunched {

--- a/contracts/src/factory/interface.cairo
+++ b/contracts/src/factory/interface.cairo
@@ -19,7 +19,6 @@ trait IFactory<TContractState> {
     /// * `initial_supply` - The initial supply of the Memecoin.
     /// * `initial_holders` - An array containing the initial holders' addresses.
     /// * `initial_holders_amounts` - An array containing the initial amounts held by each corresponding initial holder.
-    /// * `transfer_limit_delay` - The delay in seconds during which transfers will be limited to a % of max supply after launch.
     /// * `quote_token` - The address of the quote token
     /// * `contract_address_salt` - A unique salt value for contract deployment
     ///
@@ -34,7 +33,6 @@ trait IFactory<TContractState> {
         initial_supply: u256,
         initial_holders: Span<ContractAddress>,
         initial_holders_amounts: Span<u256>,
-        transfer_limit_delay: u64,
         contract_address_salt: felt252
     ) -> ContractAddress;
 
@@ -47,6 +45,7 @@ trait IFactory<TContractState> {
     /// # Arguments
     ///
     /// * `memecoin_address` - The address of the memecoin contract.
+    /// * `transfer_restriction_delay` - The delay in seconds during which transfers will be limited to a % of max supply after launch.
     /// * `quote_address` - The address of the quote token contract.
     /// * `quote_amount` - The amount of quote tokens to add as liquidity.
     /// * `unlock_time` - The timestamp when the liquidity can be unlocked.
@@ -65,6 +64,7 @@ trait IFactory<TContractState> {
     fn launch_on_jediswap(
         ref self: TContractState,
         memecoin_address: ContractAddress,
+        transfer_restriction_delay: u64,
         quote_address: ContractAddress,
         quote_amount: u256,
         unlock_time: u64,
@@ -78,6 +78,7 @@ trait IFactory<TContractState> {
     /// # Arguments
     ///
     /// * `memecoin_address` - The address of the memecoin contract.
+    /// * `transfer_restriction_delay` - The delay in seconds during which transfers will be limited to a % of max supply after launch.
     /// * `quote_address` - The address of the quote token contract.
     /// * `ekubo_parameters` - The parameters for the ekubo liquidity pool, including:
     ///     - `fee` - The fee for the liquidity pair.
@@ -100,6 +101,7 @@ trait IFactory<TContractState> {
     fn launch_on_ekubo(
         ref self: TContractState,
         memecoin_address: ContractAddress,
+        transfer_restriction_delay: u64,
         quote_address: ContractAddress,
         ekubo_parameters: EkuboPoolParameters,
     ) -> (u64, EkuboLP);

--- a/contracts/src/tests/fork_tests/test_ekubo.cairo
+++ b/contracts/src/tests/fork_tests/test_ekubo.cairo
@@ -29,7 +29,7 @@ use unruggable::tests::fork_tests::utils::{
 };
 use unruggable::tests::unit_tests::utils::{
     OWNER, DEFAULT_MIN_LOCKTIME, pow_256, LOCK_MANAGER_ADDRESS, MEMEFACTORY_ADDRESS, RECIPIENT,
-    ALICE, DefaultTxInfoMock
+    ALICE, DefaultTxInfoMock, TRANSFER_RESTRICTION_DELAY,
 };
 use unruggable::token::interface::{
     IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
@@ -48,6 +48,7 @@ fn launch_memecoin_on_ekubo(
     let (id, position) = factory
         .launch_on_ekubo(
             memecoin_address,
+            TRANSFER_RESTRICTION_DELAY,
             quote_address,
             EkuboPoolParameters { fee, tick_spacing, starting_tick, bound }
         );
@@ -616,6 +617,7 @@ fn test_cant_launch_twice() {
     let (id, position) = factory
         .launch_on_ekubo(
             memecoin_address,
+            TRANSFER_RESTRICTION_DELAY,
             quote_address,
             EkuboPoolParameters {
                 fee: 0xc49ba5e353f7d00000000000000000,

--- a/contracts/src/tests/fork_tests/test_jediswap.cairo
+++ b/contracts/src/tests/fork_tests/test_jediswap.cairo
@@ -13,7 +13,7 @@ use unruggable::tests::addresses::{JEDI_FACTORY_ADDRESS, JEDI_ROUTER_ADDRESS, ET
 use unruggable::tests::fork_tests::utils::{deploy_memecoin_through_factory_with_owner, sort_tokens};
 use unruggable::tests::unit_tests::utils::{
     OWNER, DEFAULT_MIN_LOCKTIME, pow_256, LOCK_MANAGER_ADDRESS, MEMEFACTORY_ADDRESS,
-    deploy_eth_with_owner
+    deploy_eth_with_owner, TRANSFER_RESTRICTION_DELAY
 };
 use unruggable::token::interface::{IUnruggableMemecoinDispatcherTrait};
 use unruggable::token::memecoin::LiquidityType;
@@ -37,7 +37,7 @@ fn test_jediswap_integration() {
     stop_prank(CheatTarget::One(quote.contract_address));
 
     let pair_address = factory
-        .launch_on_jediswap(memecoin_address, quote_address, amount, unlock_time);
+        .launch_on_jediswap(memecoin_address, TRANSFER_RESTRICTION_DELAY, quote_address, amount, unlock_time);
 
     let pair = IJediswapPairDispatcher { contract_address: pair_address };
 

--- a/contracts/src/tests/fork_tests/test_jediswap.cairo
+++ b/contracts/src/tests/fork_tests/test_jediswap.cairo
@@ -37,7 +37,9 @@ fn test_jediswap_integration() {
     stop_prank(CheatTarget::One(quote.contract_address));
 
     let pair_address = factory
-        .launch_on_jediswap(memecoin_address, TRANSFER_RESTRICTION_DELAY, quote_address, amount, unlock_time);
+        .launch_on_jediswap(
+            memecoin_address, TRANSFER_RESTRICTION_DELAY, quote_address, amount, unlock_time
+        );
 
     let pair = IJediswapPairDispatcher { contract_address: pair_address };
 

--- a/contracts/src/tests/fork_tests/utils.cairo
+++ b/contracts/src/tests/fork_tests/utils.cairo
@@ -14,7 +14,7 @@ use unruggable::tests::addresses::{
 };
 use unruggable::tests::unit_tests::utils::{
     deploy_locker, deploy_eth_with_owner, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, INITIAL_HOLDERS,
-    INITIAL_HOLDERS_AMOUNTS, TRANSFER_LIMIT_DELAY, SALT, DefaultTxInfoMock, OWNER, TOKEN0_ADDRESS,
+    INITIAL_HOLDERS_AMOUNTS, SALT, DefaultTxInfoMock, OWNER, TOKEN0_ADDRESS,
     MEMEFACTORY_ADDRESS
 };
 use unruggable::token::interface::{
@@ -109,7 +109,6 @@ fn deploy_memecoin_through_factory_with_owner(
             initial_supply: DEFAULT_INITIAL_SUPPLY(),
             initial_holders: INITIAL_HOLDERS(),
             initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
-            transfer_limit_delay: TRANSFER_LIMIT_DELAY,
             contract_address_salt: SALT(),
         );
     stop_prank(CheatTarget::One(memecoin_factory.contract_address));

--- a/contracts/src/tests/fork_tests/utils.cairo
+++ b/contracts/src/tests/fork_tests/utils.cairo
@@ -14,8 +14,7 @@ use unruggable::tests::addresses::{
 };
 use unruggable::tests::unit_tests::utils::{
     deploy_locker, deploy_eth_with_owner, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, INITIAL_HOLDERS,
-    INITIAL_HOLDERS_AMOUNTS, SALT, DefaultTxInfoMock, OWNER, TOKEN0_ADDRESS,
-    MEMEFACTORY_ADDRESS
+    INITIAL_HOLDERS_AMOUNTS, SALT, DefaultTxInfoMock, OWNER, TOKEN0_ADDRESS, MEMEFACTORY_ADDRESS
 };
 use unruggable::token::interface::{
     IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait

--- a/contracts/src/tests/unit_tests/test_factory.cairo
+++ b/contracts/src/tests/unit_tests/test_factory.cairo
@@ -20,7 +20,7 @@ use unruggable::tests::unit_tests::utils::{
     SYMBOL, DEFAULT_INITIAL_SUPPLY, INITIAL_HOLDERS, INITIAL_HOLDERS_AMOUNTS, SALT,
     deploy_memecoin_through_factory, MEMEFACTORY_ADDRESS,
     deploy_memecoin_through_factory_with_owner, pow_256, LOCK_MANAGER_ADDRESS, DEFAULT_MIN_LOCKTIME,
-    deploy_and_launch_memecoin
+    deploy_and_launch_memecoin, TRANSFER_RESTRICTION_DELAY
 };
 use unruggable::token::interface::{
     IUnruggableMemecoin, IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
@@ -97,7 +97,6 @@ fn test_create_memecoin() {
             initial_supply: DEFAULT_INITIAL_SUPPLY(),
             initial_holders: INITIAL_HOLDERS(),
             initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
-            transfer_limit_delay: 1000,
             contract_address_salt: SALT(),
         );
     stop_prank(CheatTarget::One(memecoin_factory.contract_address));
@@ -140,7 +139,7 @@ fn test_launch_memecoin_happy_path() {
     start_warp(CheatTarget::One(memecoin_address), 1);
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address, eth.contract_address, eth_amount, DEFAULT_MIN_LOCKTIME,
+            memecoin_address, TRANSFER_RESTRICTION_DELAY, eth.contract_address, eth_amount, DEFAULT_MIN_LOCKTIME,
         );
     stop_prank(CheatTarget::One(factory.contract_address));
     stop_warp(CheatTarget::One(memecoin_address));
@@ -191,7 +190,7 @@ fn test_launch_memecoin_already_launched() {
     start_prank(CheatTarget::One(factory.contract_address), OWNER());
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address, eth.contract_address, eth_amount, DEFAULT_MIN_LOCKTIME,
+            memecoin_address, TRANSFER_RESTRICTION_DELAY, eth.contract_address, eth_amount, DEFAULT_MIN_LOCKTIME,
         );
 }
 
@@ -201,7 +200,7 @@ fn test_launch_memecoin_not_owner() {
     let (memecoin, memecoin_address) = deploy_memecoin_through_factory();
     let factory = IFactoryDispatcher { contract_address: MEMEFACTORY_ADDRESS() };
     let pair_address = factory
-        .launch_on_jediswap(memecoin_address, ETH_ADDRESS(), 1, DEFAULT_MIN_LOCKTIME,);
+        .launch_on_jediswap(memecoin_address, TRANSFER_RESTRICTION_DELAY, ETH_ADDRESS(), 1, DEFAULT_MIN_LOCKTIME,);
 }
 
 #[test]
@@ -218,6 +217,7 @@ fn test_launch_memecoin_amm_not_whitelisted() {
     let pool_address = factory
         .launch_on_ekubo(
             memecoin_address,
+            TRANSFER_RESTRICTION_DELAY,
             eth.contract_address,
             EkuboPoolParameters {
                 fee: 0, tick_spacing: 0, starting_tick: i129 { sign: false, mag: 0 }, bound: 0

--- a/contracts/src/tests/unit_tests/test_factory.cairo
+++ b/contracts/src/tests/unit_tests/test_factory.cairo
@@ -139,7 +139,11 @@ fn test_launch_memecoin_happy_path() {
     start_warp(CheatTarget::One(memecoin_address), 1);
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address, TRANSFER_RESTRICTION_DELAY, eth.contract_address, eth_amount, DEFAULT_MIN_LOCKTIME,
+            memecoin_address,
+            TRANSFER_RESTRICTION_DELAY,
+            eth.contract_address,
+            eth_amount,
+            DEFAULT_MIN_LOCKTIME,
         );
     stop_prank(CheatTarget::One(factory.contract_address));
     stop_warp(CheatTarget::One(memecoin_address));
@@ -190,7 +194,11 @@ fn test_launch_memecoin_already_launched() {
     start_prank(CheatTarget::One(factory.contract_address), OWNER());
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address, TRANSFER_RESTRICTION_DELAY, eth.contract_address, eth_amount, DEFAULT_MIN_LOCKTIME,
+            memecoin_address,
+            TRANSFER_RESTRICTION_DELAY,
+            eth.contract_address,
+            eth_amount,
+            DEFAULT_MIN_LOCKTIME,
         );
 }
 
@@ -200,7 +208,9 @@ fn test_launch_memecoin_not_owner() {
     let (memecoin, memecoin_address) = deploy_memecoin_through_factory();
     let factory = IFactoryDispatcher { contract_address: MEMEFACTORY_ADDRESS() };
     let pair_address = factory
-        .launch_on_jediswap(memecoin_address, TRANSFER_RESTRICTION_DELAY, ETH_ADDRESS(), 1, DEFAULT_MIN_LOCKTIME,);
+        .launch_on_jediswap(
+            memecoin_address, TRANSFER_RESTRICTION_DELAY, ETH_ADDRESS(), 1, DEFAULT_MIN_LOCKTIME,
+        );
 }
 
 #[test]

--- a/contracts/src/tests/unit_tests/test_memecoin_erc20.cairo
+++ b/contracts/src/tests/unit_tests/test_memecoin_erc20.cairo
@@ -9,7 +9,8 @@ use starknet::{ContractAddress, contract_address_const};
 use unruggable::exchanges::{SupportedExchanges};
 use unruggable::tests::unit_tests::utils::{
     OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, RECIPIENT, SPENDER, deploy_locker, INITIAL_HOLDERS,
-    INITIAL_HOLDERS_AMOUNTS, TRANSFER_RESTRICTION_DELAY, DefaultTxInfoMock, deploy_standalone_memecoin
+    INITIAL_HOLDERS_AMOUNTS, TRANSFER_RESTRICTION_DELAY, DefaultTxInfoMock,
+    deploy_standalone_memecoin
 };
 use unruggable::token::interface::{
     IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
@@ -58,8 +59,7 @@ mod erc20_entrypoints {
     use starknet::{ContractAddress, contract_address_const};
     use super::{
         deploy_standalone_memecoin, OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, RECIPIENT, SPENDER,
-        deploy_locker, INITIAL_HOLDERS, DefaultTxInfoMock,
-        INITIAL_HOLDERS_AMOUNTS
+        deploy_locker, INITIAL_HOLDERS, DefaultTxInfoMock, INITIAL_HOLDERS_AMOUNTS
     };
     use unruggable::token::interface::{
         IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait

--- a/contracts/src/tests/unit_tests/test_memecoin_erc20.cairo
+++ b/contracts/src/tests/unit_tests/test_memecoin_erc20.cairo
@@ -9,7 +9,7 @@ use starknet::{ContractAddress, contract_address_const};
 use unruggable::exchanges::{SupportedExchanges};
 use unruggable::tests::unit_tests::utils::{
     OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, RECIPIENT, SPENDER, deploy_locker, INITIAL_HOLDERS,
-    INITIAL_HOLDERS_AMOUNTS, TRANSFER_LIMIT_DELAY, DefaultTxInfoMock, deploy_standalone_memecoin
+    INITIAL_HOLDERS_AMOUNTS, TRANSFER_RESTRICTION_DELAY, DefaultTxInfoMock, deploy_standalone_memecoin
 };
 use unruggable::token::interface::{
     IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
@@ -23,7 +23,7 @@ mod erc20_metadata {
     use starknet::{ContractAddress, contract_address_const};
     use super::{
         deploy_standalone_memecoin, OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, RECIPIENT, SPENDER,
-        deploy_locker, TRANSFER_LIMIT_DELAY
+        deploy_locker
     };
     use unruggable::token::interface::{
         IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
@@ -58,7 +58,7 @@ mod erc20_entrypoints {
     use starknet::{ContractAddress, contract_address_const};
     use super::{
         deploy_standalone_memecoin, OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, RECIPIENT, SPENDER,
-        deploy_locker, TRANSFER_LIMIT_DELAY, INITIAL_HOLDERS, DefaultTxInfoMock,
+        deploy_locker, INITIAL_HOLDERS, DefaultTxInfoMock,
         INITIAL_HOLDERS_AMOUNTS
     };
     use unruggable::token::interface::{

--- a/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
+++ b/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
@@ -124,9 +124,7 @@ mod test_constructor {
     #[test]
     #[should_panic(expected: ('Max team allocation reached',))]
     fn test_constructor_too_much_team_alloc_should_fail() {
-        let mut calldata = array![
-            OWNER().into(), 'locker', NAME().into(), SYMBOL().into()
-        ];
+        let mut calldata = array![OWNER().into(), 'locker', NAME().into(), SYMBOL().into()];
         // Allocation over 10% (over 2.1M)
         let alloc_holder_1 = 1_050_000 * pow_256(10, 18);
         let alloc_holder_2 = 1_050_001 * pow_256(10, 18);
@@ -247,7 +245,8 @@ mod memecoin_entrypoints {
         // setting block timestamp >= launch_time + transfer_delay. Transfer should succeed
         // as multi calls to the same recipient are allowed after the delay
         start_warp(
-            CheatTarget::One(memecoin.contract_address), launch_timestamp + TRANSFER_RESTRICTION_DELAY
+            CheatTarget::One(memecoin.contract_address),
+            launch_timestamp + TRANSFER_RESTRICTION_DELAY
         );
         start_prank(CheatTarget::One(memecoin.contract_address), INITIAL_HOLDER_1());
         let send_amount = memecoin.transfer_from(INITIAL_HOLDER_1(), ALICE(), 0);

--- a/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
+++ b/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
@@ -10,7 +10,7 @@ use starknet::{ContractAddress, contract_address_const};
 use unruggable::exchanges::{SupportedExchanges};
 use unruggable::tests::unit_tests::utils::{
     OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, RECIPIENT, SPENDER, deploy_locker, INITIAL_HOLDERS,
-    INITIAL_HOLDERS_AMOUNTS, TRANSFER_LIMIT_DELAY, DefaultTxInfoMock,
+    INITIAL_HOLDERS_AMOUNTS, TRANSFER_RESTRICTION_DELAY, DefaultTxInfoMock,
     deploy_memecoin_through_factory
 };
 use unruggable::token::interface::{
@@ -33,7 +33,7 @@ mod test_constructor {
         deploy_eth_with_owner, OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, INITIAL_HOLDERS,
         INITIAL_HOLDER_1, INITIAL_HOLDER_2, INITIAL_HOLDERS_AMOUNTS, SALT, DefaultTxInfoMock,
         deploy_memecoin_through_factory, ETH_ADDRESS, deploy_memecoin_through_factory_with_owner,
-        JEDI_ROUTER_ADDRESS, MEMEFACTORY_ADDRESS, ALICE, BOB, TRANSFER_LIMIT_DELAY, pow_256,
+        JEDI_ROUTER_ADDRESS, MEMEFACTORY_ADDRESS, ALICE, BOB, TRANSFER_RESTRICTION_DELAY, pow_256,
         LOCK_MANAGER_ADDRESS, JEDI_FACTORY_ADDRESS
     };
     use unruggable::token::UnruggableMemecoin;
@@ -51,7 +51,6 @@ mod test_constructor {
         UnruggableMemecoin::constructor(
             ref memecoin,
             OWNER(),
-            TRANSFER_LIMIT_DELAY,
             NAME(),
             SYMBOL(),
             DEFAULT_INITIAL_SUPPLY(),
@@ -65,10 +64,6 @@ mod test_constructor {
         );
 
         // Check internals that must be set upon deployment
-        assert(
-            memecoin.transfer_restriction_delay.read() == TRANSFER_LIMIT_DELAY,
-            'wrong transfer limit delay'
-        );
         assert(
             memecoin.team_allocation.read() == 2_100_000 * pow_256(10, 18), 'wrong team allocation'
         ); // 10% of supply
@@ -88,7 +83,6 @@ mod test_constructor {
         UnruggableMemecoin::constructor(
             ref state,
             OWNER(),
-            TRANSFER_LIMIT_DELAY,
             NAME(),
             SYMBOL(),
             DEFAULT_INITIAL_SUPPLY(),
@@ -119,7 +113,6 @@ mod test_constructor {
         UnruggableMemecoin::constructor(
             ref state,
             OWNER(),
-            TRANSFER_LIMIT_DELAY,
             NAME(),
             SYMBOL(),
             DEFAULT_INITIAL_SUPPLY(),
@@ -132,7 +125,7 @@ mod test_constructor {
     #[should_panic(expected: ('Max team allocation reached',))]
     fn test_constructor_too_much_team_alloc_should_fail() {
         let mut calldata = array![
-            OWNER().into(), 'locker', TRANSFER_LIMIT_DELAY.into(), NAME().into(), SYMBOL().into()
+            OWNER().into(), 'locker', NAME().into(), SYMBOL().into()
         ];
         // Allocation over 10% (over 2.1M)
         let alloc_holder_1 = 1_050_000 * pow_256(10, 18);
@@ -141,7 +134,6 @@ mod test_constructor {
         UnruggableMemecoin::constructor(
             ref state,
             OWNER(),
-            TRANSFER_LIMIT_DELAY,
             NAME(),
             SYMBOL(),
             DEFAULT_INITIAL_SUPPLY(),
@@ -171,7 +163,7 @@ mod memecoin_entrypoints {
         INITIAL_HOLDER_1, INITIAL_HOLDER_2, INITIAL_HOLDERS_AMOUNTS, SALT, DefaultTxInfoMock,
         deploy_memecoin_through_factory, ETH_ADDRESS, deploy_memecoin_through_factory_with_owner,
         JEDI_ROUTER_ADDRESS, MEMEFACTORY_ADDRESS, ALICE, BOB, pow_256, LOCK_MANAGER_ADDRESS,
-        deploy_and_launch_memecoin, TRANSFER_LIMIT_DELAY, UNLOCK_TIME, DEFAULT_MIN_LOCKTIME
+        deploy_and_launch_memecoin, TRANSFER_RESTRICTION_DELAY, UNLOCK_TIME, DEFAULT_MIN_LOCKTIME
     };
     use unruggable::token::interface::{
         IUnruggableMemecoin, IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
@@ -255,7 +247,7 @@ mod memecoin_entrypoints {
         // setting block timestamp >= launch_time + transfer_delay. Transfer should succeed
         // as multi calls to the same recipient are allowed after the delay
         start_warp(
-            CheatTarget::One(memecoin.contract_address), launch_timestamp + TRANSFER_LIMIT_DELAY
+            CheatTarget::One(memecoin.contract_address), launch_timestamp + TRANSFER_RESTRICTION_DELAY
         );
         start_prank(CheatTarget::One(memecoin.contract_address), INITIAL_HOLDER_1());
         let send_amount = memecoin.transfer_from(INITIAL_HOLDER_1(), ALICE(), 0);
@@ -313,7 +305,7 @@ mod memecoin_internals {
             // create a unique address
             let unique_recipient: ContractAddress = (index.into() + 9999).try_into().unwrap();
 
-            // creating and setting unique tx_hash here 
+            // creating and setting unique tx_hash here
             let mut tx_info: TxInfoMock = Default::default();
             tx_info.transaction_hash = Option::Some(index.into() + 9999);
             snforge_std::start_spoof(CheatTarget::One(memecoin.contract_address), tx_info);
@@ -348,7 +340,7 @@ mod memecoin_internals {
                 break;
             }
 
-            // creating and setting unique tx_hash here 
+            // creating and setting unique tx_hash here
             let mut tx_info: TxInfoMock = Default::default();
             tx_info.transaction_hash = Option::Some(index.into() + 9999);
             snforge_std::start_spoof(CheatTarget::One(memecoin.contract_address), tx_info);
@@ -377,7 +369,7 @@ mod memecoin_internals {
             // create a unique address
             let unique_recipient: ContractAddress = (index.into() + 9999).try_into().unwrap();
 
-            // creating and setting unique tx_hash here 
+            // creating and setting unique tx_hash here
             let mut tx_info: TxInfoMock = Default::default();
             tx_info.transaction_hash = Option::Some(index.into() + 9999);
             snforge_std::start_spoof(CheatTarget::One(memecoin.contract_address), tx_info);
@@ -404,7 +396,7 @@ mod memecoin_internals {
             // create a unique address
             let unique_recipient: ContractAddress = (index.into() + 9999).try_into().unwrap();
 
-            // creating and setting unique tx_hash here 
+            // creating and setting unique tx_hash here
             let mut tx_info: TxInfoMock = Default::default();
             tx_info.transaction_hash = Option::Some(index.into() + 9999);
             snforge_std::start_spoof(CheatTarget::One(memecoin.contract_address), tx_info);

--- a/contracts/src/tests/unit_tests/utils.cairo
+++ b/contracts/src/tests/unit_tests/utils.cairo
@@ -105,9 +105,7 @@ fn deploy_standalone_memecoin() -> (IUnruggableMemecoinDispatcher, ContractAddre
 
     // Deploy the memecoin with the default parameters.
     let contract = declare('UnruggableMemecoin');
-    let mut calldata = array![
-        OWNER().into(), NAME().into(), SYMBOL().into(),
-    ];
+    let mut calldata = array![OWNER().into(), NAME().into(), SYMBOL().into(),];
     Serde::serialize(@DEFAULT_INITIAL_SUPPLY(), ref calldata);
     Serde::serialize(@INITIAL_HOLDERS(), ref calldata);
     Serde::serialize(@INITIAL_HOLDERS_AMOUNTS(), ref calldata);
@@ -274,7 +272,11 @@ fn deploy_and_launch_memecoin() -> (IUnruggableMemecoinDispatcher, ContractAddre
     start_warp(CheatTarget::One(memecoin_address), 1);
     let pool_address = factory
         .launch_on_jediswap(
-            memecoin_address, TRANSFER_RESTRICTION_DELAY, eth.contract_address, eth_amount, DEFAULT_MIN_LOCKTIME,
+            memecoin_address,
+            TRANSFER_RESTRICTION_DELAY,
+            eth.contract_address,
+            eth_amount,
+            DEFAULT_MIN_LOCKTIME,
         );
     stop_prank(CheatTarget::One(factory.contract_address));
     stop_warp(CheatTarget::One(memecoin_address));

--- a/contracts/src/tests/unit_tests/utils.cairo
+++ b/contracts/src/tests/unit_tests/utils.cairo
@@ -83,7 +83,7 @@ fn UNLOCK_TIME() -> u64 {
 }
 
 const ETH_DECIMALS: u8 = 18;
-const TRANSFER_LIMIT_DELAY: u64 = 1000;
+const TRANSFER_RESTRICTION_DELAY: u64 = 1000;
 
 
 fn MEMEFACTORY_ADDRESS() -> ContractAddress {
@@ -106,7 +106,7 @@ fn deploy_standalone_memecoin() -> (IUnruggableMemecoinDispatcher, ContractAddre
     // Deploy the memecoin with the default parameters.
     let contract = declare('UnruggableMemecoin');
     let mut calldata = array![
-        OWNER().into(), TRANSFER_LIMIT_DELAY.into(), NAME().into(), SYMBOL().into(),
+        OWNER().into(), NAME().into(), SYMBOL().into(),
     ];
     Serde::serialize(@DEFAULT_INITIAL_SUPPLY(), ref calldata);
     Serde::serialize(@INITIAL_HOLDERS(), ref calldata);
@@ -237,7 +237,6 @@ fn deploy_memecoin_through_factory_with_owner(
             initial_supply: DEFAULT_INITIAL_SUPPLY(),
             initial_holders: INITIAL_HOLDERS(),
             initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
-            transfer_limit_delay: TRANSFER_LIMIT_DELAY,
             contract_address_salt: SALT(),
         );
     stop_prank(CheatTarget::One(memecoin_factory.contract_address));
@@ -275,7 +274,7 @@ fn deploy_and_launch_memecoin() -> (IUnruggableMemecoinDispatcher, ContractAddre
     start_warp(CheatTarget::One(memecoin_address), 1);
     let pool_address = factory
         .launch_on_jediswap(
-            memecoin_address, eth.contract_address, eth_amount, DEFAULT_MIN_LOCKTIME,
+            memecoin_address, TRANSFER_RESTRICTION_DELAY, eth.contract_address, eth_amount, DEFAULT_MIN_LOCKTIME,
         );
     stop_prank(CheatTarget::One(factory.contract_address));
     stop_warp(CheatTarget::One(memecoin_address));

--- a/contracts/src/token/interface.cairo
+++ b/contracts/src/token/interface.cairo
@@ -45,13 +45,13 @@ trait IUnruggableMemecoin<TState> {
     // ************************************
     /// Checks whether token has launched
     ///
-    /// # Returns 
+    /// # Returns
     ///     bool: whether token has launched
     fn is_launched(self: @TState) -> bool;
     fn liquidity_type(self: @TState) -> Option<LiquidityType>;
     fn get_team_allocation(self: @TState) -> u256;
     fn memecoin_factory_address(self: @TState) -> ContractAddress;
-    fn set_launched(ref self: TState, liquidity_type: LiquidityType);
+    fn set_launched(ref self: TState, liquidity_type: LiquidityType, transfer_restriction_delay: u64);
 }
 
 #[starknet::interface]
@@ -101,6 +101,7 @@ trait IUnruggableAdditional<TState> {
     /// # Arguments
     ///
     /// * `liquidity_type` - The liquidity position at the time of launch.
+    /// * `transfer_restriction_delay` - The delay in seconds before transfers are no longer limited.
     ///
     /// # Panics
     ///
@@ -109,5 +110,5 @@ trait IUnruggableAdditional<TState> {
     /// * The caller's address is not the same as the `factory` of the memecoin (error code: `errors::CALLER_NOT_FACTORY`).
     /// * The memecoin has already been launched (error code: `errors::ALREADY_LAUNCHED`).
     ///
-    fn set_launched(ref self: TState, liquidity_type: LiquidityType);
+    fn set_launched(ref self: TState, liquidity_type: LiquidityType, transfer_restriction_delay: u64);
 }

--- a/contracts/src/token/interface.cairo
+++ b/contracts/src/token/interface.cairo
@@ -51,7 +51,9 @@ trait IUnruggableMemecoin<TState> {
     fn liquidity_type(self: @TState) -> Option<LiquidityType>;
     fn get_team_allocation(self: @TState) -> u256;
     fn memecoin_factory_address(self: @TState) -> ContractAddress;
-    fn set_launched(ref self: TState, liquidity_type: LiquidityType, transfer_restriction_delay: u64);
+    fn set_launched(
+        ref self: TState, liquidity_type: LiquidityType, transfer_restriction_delay: u64
+    );
 }
 
 #[starknet::interface]
@@ -110,5 +112,7 @@ trait IUnruggableAdditional<TState> {
     /// * The caller's address is not the same as the `factory` of the memecoin (error code: `errors::CALLER_NOT_FACTORY`).
     /// * The memecoin has already been launched (error code: `errors::ALREADY_LAUNCHED`).
     ///
-    fn set_launched(ref self: TState, liquidity_type: LiquidityType, transfer_restriction_delay: u64);
+    fn set_launched(
+        ref self: TState, liquidity_type: LiquidityType, transfer_restriction_delay: u64
+    );
 }

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -94,7 +94,6 @@ mod UnruggableMemecoin {
     /// Constructor called once when the contract is deployed.
     /// # Arguments
     /// * `owner` - The owner of the contract.
-    /// * `transfer_restriction_delay` - Delay timestamp to release transfer amount check.
     /// * `name` - The name of the token.
     /// * `symbol` - The symbol of the token.
     /// * `initial_supply` - The initial supply of the token.
@@ -104,7 +103,6 @@ mod UnruggableMemecoin {
     fn constructor(
         ref self: ContractState,
         owner: ContractAddress,
-        transfer_restriction_delay: u64,
         name: felt252,
         symbol: felt252,
         initial_supply: u256,
@@ -121,7 +119,6 @@ mod UnruggableMemecoin {
         self
             .initializer(
                 factory_address: get_caller_address(),
-                :transfer_restriction_delay,
                 :initial_supply,
                 :initial_holders,
                 :initial_holders_amounts
@@ -147,11 +144,18 @@ mod UnruggableMemecoin {
             self.liquidity_type.read()
         }
 
-        fn set_launched(ref self: ContractState, liquidity_type: LiquidityType) {
+        fn set_launched(ref self: ContractState, liquidity_type: LiquidityType, transfer_restriction_delay: u64) {
             self.assert_only_factory();
             assert(!self.is_launched(), errors::ALREADY_LAUNCHED);
+
             self.liquidity_type.write(Option::Some(liquidity_type));
             self.launch_time.write(get_block_timestamp());
+
+            // Enable a transfer limit - until this time has passed,
+            // transfers are limited to a certain amount.
+            self.transfer_restriction_delay.write(transfer_restriction_delay);
+
+            // renounce ownership
             self.ownable._transfer_ownership(0.try_into().unwrap());
         }
     }
@@ -221,7 +225,8 @@ mod UnruggableMemecoin {
         fn assert_only_factory(self: @ContractState) {
             assert(get_caller_address() == self.factory_contract.read(), errors::NOT_FACTORY);
         }
-        // Initializes the state of the memecoin contract.
+
+        /// Initializes the state of the memecoin contract.
         ///
         /// This function sets the factory contract address, enables a transfer limit delay,
         /// checks and allocates the team supply of the memecoin, and mints the remaining supply to the factory.
@@ -229,7 +234,6 @@ mod UnruggableMemecoin {
         /// # Arguments
         ///
         /// * `factory_address` - The address of the factory contract.
-        /// * `transfer_restriction_delay` - The delay in seconds before transfers are no longer limited.
         /// * `initial_supply` - The initial supply of the memecoin.
         /// * `initial_holders` - A span of addresses that will hold the memecoin initially.
         /// * `initial_holders_amounts` - A span of amounts corresponding to the initial holders.
@@ -239,17 +243,12 @@ mod UnruggableMemecoin {
         fn initializer(
             ref self: ContractState,
             factory_address: ContractAddress,
-            transfer_restriction_delay: u64,
             initial_supply: u256,
             initial_holders: Span<ContractAddress>,
             initial_holders_amounts: Span<u256>
         ) {
             // Internal Registry
             self.factory_contract.write(factory_address);
-
-            // Enable a transfer limit - until this time has passed,
-            // transfers are limited to a certain amount.
-            self.transfer_restriction_delay.write(transfer_restriction_delay);
 
             let team_allocation = self
                 .check_and_allocate_team_supply(

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -144,7 +144,9 @@ mod UnruggableMemecoin {
             self.liquidity_type.read()
         }
 
-        fn set_launched(ref self: ContractState, liquidity_type: LiquidityType, transfer_restriction_delay: u64) {
+        fn set_launched(
+            ref self: ContractState, liquidity_type: LiquidityType, transfer_restriction_delay: u64
+        ) {
             self.assert_only_factory();
             assert(!self.is_launched(), errors::ALREADY_LAUNCHED);
 


### PR DESCRIPTION
with this PR, transfer restriction delay has to be provided at memecoin launch instead of creation.