### PR TITLE
Max percentage buy provided at launch

### DIFF
--- a/contracts/src/errors.cairo
+++ b/contracts/src/errors.cairo
@@ -8,3 +8,4 @@ const NOT_FACTORY: felt252 = 'Caller not factory';
 const CALLER_NOT_OWNER: felt252 = 'Caller is not the owner';
 const ALREADY_LAUNCHED: felt252 = 'Already launched';
 const PRICE_ZERO: felt252 = 'Starting tick cannot be 0';
+const MAX_PERCENTAGE_BUY_LAUNCH_TOO_LOW: felt252 = 'Max percentage buy too low';

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -126,6 +126,7 @@ mod Factory {
             ref self: ContractState,
             memecoin_address: ContractAddress,
             transfer_restriction_delay: u64,
+            max_percentage_buy_launch: u16,
             quote_address: ContractAddress,
             quote_amount: u256,
             unlock_time: u64,
@@ -150,7 +151,7 @@ mod Factory {
                 }
             );
 
-            memecoin.set_launched(LiquidityType::ERC20(pair_address), :transfer_restriction_delay);
+            memecoin.set_launched(LiquidityType::ERC20(pair_address), :transfer_restriction_delay, :max_percentage_buy_launch);
             self
                 .emit(
                     MemecoinLaunched {
@@ -164,6 +165,7 @@ mod Factory {
             ref self: ContractState,
             memecoin_address: ContractAddress,
             transfer_restriction_delay: u64,
+            max_percentage_buy_launch: u16,
             quote_address: ContractAddress,
             ekubo_parameters: EkuboPoolParameters,
         ) -> (u64, EkuboLP) {
@@ -183,7 +185,7 @@ mod Factory {
                 additional_parameters: ekubo_parameters
             );
 
-            memecoin.set_launched(LiquidityType::NFT(id), :transfer_restriction_delay);
+            memecoin.set_launched(LiquidityType::NFT(id), :transfer_restriction_delay, :max_percentage_buy_launch);
             self
                 .emit(
                     MemecoinLaunched {

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -151,7 +151,12 @@ mod Factory {
                 }
             );
 
-            memecoin.set_launched(LiquidityType::ERC20(pair_address), :transfer_restriction_delay, :max_percentage_buy_launch);
+            memecoin
+                .set_launched(
+                    LiquidityType::ERC20(pair_address),
+                    :transfer_restriction_delay,
+                    :max_percentage_buy_launch
+                );
             self
                 .emit(
                     MemecoinLaunched {
@@ -185,7 +190,10 @@ mod Factory {
                 additional_parameters: ekubo_parameters
             );
 
-            memecoin.set_launched(LiquidityType::NFT(id), :transfer_restriction_delay, :max_percentage_buy_launch);
+            memecoin
+                .set_launched(
+                    LiquidityType::NFT(id), :transfer_restriction_delay, :max_percentage_buy_launch
+                );
             self
                 .emit(
                     MemecoinLaunched {

--- a/contracts/src/factory/interface.cairo
+++ b/contracts/src/factory/interface.cairo
@@ -46,6 +46,7 @@ trait IFactory<TContractState> {
     ///
     /// * `memecoin_address` - The address of the memecoin contract.
     /// * `transfer_restriction_delay` - The delay in seconds during which transfers will be limited to a % of max supply after launch.
+    /// * `max_percentage_buy_launch` - The max buyable amount in % of the max supply after launch and during the transfer restriction delay.
     /// * `quote_address` - The address of the quote token contract.
     /// * `quote_amount` - The amount of quote tokens to add as liquidity.
     /// * `unlock_time` - The timestamp when the liquidity can be unlocked.
@@ -65,6 +66,7 @@ trait IFactory<TContractState> {
         ref self: TContractState,
         memecoin_address: ContractAddress,
         transfer_restriction_delay: u64,
+        max_percentage_buy_launch: u16,
         quote_address: ContractAddress,
         quote_amount: u256,
         unlock_time: u64,
@@ -102,6 +104,7 @@ trait IFactory<TContractState> {
         ref self: TContractState,
         memecoin_address: ContractAddress,
         transfer_restriction_delay: u64,
+        max_percentage_buy_launch: u16,
         quote_address: ContractAddress,
         ekubo_parameters: EkuboPoolParameters,
     ) -> (u64, EkuboLP);

--- a/contracts/src/tests/fork_tests/test_ekubo.cairo
+++ b/contracts/src/tests/fork_tests/test_ekubo.cairo
@@ -29,7 +29,7 @@ use unruggable::tests::fork_tests::utils::{
 };
 use unruggable::tests::unit_tests::utils::{
     OWNER, DEFAULT_MIN_LOCKTIME, pow_256, LOCK_MANAGER_ADDRESS, MEMEFACTORY_ADDRESS, RECIPIENT,
-    ALICE, DefaultTxInfoMock, TRANSFER_RESTRICTION_DELAY,
+    ALICE, DefaultTxInfoMock, TRANSFER_RESTRICTION_DELAY, MAX_PERCENTAGE_BUY_LAUNCH
 };
 use unruggable::token::interface::{
     IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
@@ -49,6 +49,7 @@ fn launch_memecoin_on_ekubo(
         .launch_on_ekubo(
             memecoin_address,
             TRANSFER_RESTRICTION_DELAY,
+            MAX_PERCENTAGE_BUY_LAUNCH,
             quote_address,
             EkuboPoolParameters { fee, tick_spacing, starting_tick, bound }
         );
@@ -301,7 +302,7 @@ fn test_swap_token0_price_below_1() {
     };
 
     // Check that swaps work correctly
-    let amount_in = 2 * pow_256(10, 16);
+    let amount_in = MAX_PERCENTAGE_BUY_LAUNCH.into() * pow_256(10, 14);
     swap_tokens_on_ekubo(
         token_in_address: quote_address,
         :amount_in,
@@ -369,7 +370,7 @@ fn test_launch_meme_token1_price_below_1() {
     );
     assert(reserve_memecoin > expected_reserve_lower_bound, 'reserves holds too few token');
 
-    let amount_in = 2 * pow_256(10, 16);
+    let amount_in = MAX_PERCENTAGE_BUY_LAUNCH.into() * pow_256(10, 14);
     swap_tokens_on_ekubo(
         token_in_address: quote_address,
         :amount_in,
@@ -437,7 +438,7 @@ fn test_launch_meme_token0_price_above_1() {
     assert(reserve_memecoin > expected_reserve_lower_bound, 'reserves holds too few token');
 
     // Test that swaps work correctly
-    let amount_in = 2 * pow_256(10, 16);
+    let amount_in = MAX_PERCENTAGE_BUY_LAUNCH.into() * pow_256(10, 14);
     swap_tokens_on_ekubo(
         token_in_address: quote_address,
         :amount_in,
@@ -506,7 +507,7 @@ fn test_launch_meme_token1_price_above_1() {
     assert(reserve_memecoin > expected_reserve_lower_bound, 'reserves holds too few token');
 
     // Check that swaps work correctly
-    let amount_in = 2 * pow_256(10, 16);
+    let amount_in = MAX_PERCENTAGE_BUY_LAUNCH.into() * pow_256(10, 14);
     swap_tokens_on_ekubo(
         token_in_address: quote_address,
         :amount_in,
@@ -618,6 +619,7 @@ fn test_cant_launch_twice() {
         .launch_on_ekubo(
             memecoin_address,
             TRANSFER_RESTRICTION_DELAY,
+            MAX_PERCENTAGE_BUY_LAUNCH,
             quote_address,
             EkuboPoolParameters {
                 fee: 0xc49ba5e353f7d00000000000000000,

--- a/contracts/src/tests/fork_tests/test_jediswap.cairo
+++ b/contracts/src/tests/fork_tests/test_jediswap.cairo
@@ -13,7 +13,7 @@ use unruggable::tests::addresses::{JEDI_FACTORY_ADDRESS, JEDI_ROUTER_ADDRESS, ET
 use unruggable::tests::fork_tests::utils::{deploy_memecoin_through_factory_with_owner, sort_tokens};
 use unruggable::tests::unit_tests::utils::{
     OWNER, DEFAULT_MIN_LOCKTIME, pow_256, LOCK_MANAGER_ADDRESS, MEMEFACTORY_ADDRESS,
-    deploy_eth_with_owner, TRANSFER_RESTRICTION_DELAY
+    deploy_eth_with_owner, TRANSFER_RESTRICTION_DELAY, MAX_PERCENTAGE_BUY_LAUNCH
 };
 use unruggable::token::interface::{IUnruggableMemecoinDispatcherTrait};
 use unruggable::token::memecoin::LiquidityType;
@@ -38,7 +38,7 @@ fn test_jediswap_integration() {
 
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address, TRANSFER_RESTRICTION_DELAY, quote_address, amount, unlock_time
+            memecoin_address, TRANSFER_RESTRICTION_DELAY, MAX_PERCENTAGE_BUY_LAUNCH, quote_address, amount, unlock_time
         );
 
     let pair = IJediswapPairDispatcher { contract_address: pair_address };
@@ -50,10 +50,10 @@ fn test_jediswap_integration() {
     quote.approve(JEDI_ROUTER_ADDRESS(), 1 * pow_256(10, 18));
     stop_prank(CheatTarget::One(quote.contract_address));
 
-    // Max buy cap is 2% of total supply
+    // Max buy cap is `MAX_PERCENTAGE_BUY_LAUNCH` of total supply
     // Initial rate is roughly 1 ETH for 21M meme,
-    // so max buy is ~ 2% of 1 ETH = 0.02 ETH
-    let amount_in = 2 * pow_256(10, 16);
+    // so if max buy is ~ 2% of 1 ETH = 0.02 ETH
+    let amount_in = MAX_PERCENTAGE_BUY_LAUNCH.into() * pow_256(10, 14);
     start_prank(CheatTarget::One(router.contract_address), owner);
     let first_swap = router
         .swap_exact_tokens_for_tokens(

--- a/contracts/src/tests/fork_tests/test_jediswap.cairo
+++ b/contracts/src/tests/fork_tests/test_jediswap.cairo
@@ -38,7 +38,12 @@ fn test_jediswap_integration() {
 
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address, TRANSFER_RESTRICTION_DELAY, MAX_PERCENTAGE_BUY_LAUNCH, quote_address, amount, unlock_time
+            memecoin_address,
+            TRANSFER_RESTRICTION_DELAY,
+            MAX_PERCENTAGE_BUY_LAUNCH,
+            quote_address,
+            amount,
+            unlock_time
         );
 
     let pair = IJediswapPairDispatcher { contract_address: pair_address };

--- a/contracts/src/tests/unit_tests/test_factory.cairo
+++ b/contracts/src/tests/unit_tests/test_factory.cairo
@@ -238,7 +238,12 @@ fn test_launch_memecoin_not_owner() {
     let factory = IFactoryDispatcher { contract_address: MEMEFACTORY_ADDRESS() };
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address, TRANSFER_RESTRICTION_DELAY, MAX_PERCENTAGE_BUY_LAUNCH, ETH_ADDRESS(), 1, DEFAULT_MIN_LOCKTIME,
+            memecoin_address,
+            TRANSFER_RESTRICTION_DELAY,
+            MAX_PERCENTAGE_BUY_LAUNCH,
+            ETH_ADDRESS(),
+            1,
+            DEFAULT_MIN_LOCKTIME,
         );
 }
 

--- a/contracts/src/tests/unit_tests/utils.cairo
+++ b/contracts/src/tests/unit_tests/utils.cairo
@@ -84,6 +84,7 @@ fn UNLOCK_TIME() -> u64 {
 
 const ETH_DECIMALS: u8 = 18;
 const TRANSFER_RESTRICTION_DELAY: u64 = 1000;
+const MAX_PERCENTAGE_BUY_LAUNCH: u16 = 200; // 2%
 
 
 fn MEMEFACTORY_ADDRESS() -> ContractAddress {
@@ -274,6 +275,7 @@ fn deploy_and_launch_memecoin() -> (IUnruggableMemecoinDispatcher, ContractAddre
         .launch_on_jediswap(
             memecoin_address,
             TRANSFER_RESTRICTION_DELAY,
+            MAX_PERCENTAGE_BUY_LAUNCH,
             eth.contract_address,
             eth_amount,
             DEFAULT_MIN_LOCKTIME,

--- a/contracts/src/token/interface.cairo
+++ b/contracts/src/token/interface.cairo
@@ -52,7 +52,10 @@ trait IUnruggableMemecoin<TState> {
     fn get_team_allocation(self: @TState) -> u256;
     fn memecoin_factory_address(self: @TState) -> ContractAddress;
     fn set_launched(
-        ref self: TState, liquidity_type: LiquidityType, transfer_restriction_delay: u64, max_percentage_buy_launch: u16
+        ref self: TState,
+        liquidity_type: LiquidityType,
+        transfer_restriction_delay: u64,
+        max_percentage_buy_launch: u16
     );
 }
 
@@ -113,6 +116,9 @@ trait IUnruggableAdditional<TState> {
     /// * The memecoin has already been launched (error code: `errors::ALREADY_LAUNCHED`).
     ///
     fn set_launched(
-        ref self: TState, liquidity_type: LiquidityType, transfer_restriction_delay: u64, max_percentage_buy_launch: u16
+        ref self: TState,
+        liquidity_type: LiquidityType,
+        transfer_restriction_delay: u64,
+        max_percentage_buy_launch: u16
     );
 }

--- a/contracts/src/token/interface.cairo
+++ b/contracts/src/token/interface.cairo
@@ -52,7 +52,7 @@ trait IUnruggableMemecoin<TState> {
     fn get_team_allocation(self: @TState) -> u256;
     fn memecoin_factory_address(self: @TState) -> ContractAddress;
     fn set_launched(
-        ref self: TState, liquidity_type: LiquidityType, transfer_restriction_delay: u64
+        ref self: TState, liquidity_type: LiquidityType, transfer_restriction_delay: u64, max_percentage_buy_launch: u16
     );
 }
 
@@ -113,6 +113,6 @@ trait IUnruggableAdditional<TState> {
     /// * The memecoin has already been launched (error code: `errors::ALREADY_LAUNCHED`).
     ///
     fn set_launched(
-        ref self: TState, liquidity_type: LiquidityType, transfer_restriction_delay: u64
+        ref self: TState, liquidity_type: LiquidityType, transfer_restriction_delay: u64, max_percentage_buy_launch: u16
     );
 }

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -61,9 +61,8 @@ mod UnruggableMemecoin {
     /// The maximum percentage of the total supply that can be allocated to the team.
     /// This is to prevent the team from having too much control over the supply.
     const MAX_SUPPLY_PERCENTAGE_TEAM_ALLOCATION: u16 = 1_000; // 10%
-    /// The maximum percentage of the supply that can be bought at once.
-    //TODO: discuss whether this should be a constant or a parameter
-    const MAX_PERCENTAGE_BUY_LAUNCH: u8 = 200; // 2%
+    /// The minimum maximum percentage of the supply that can be bought at once.
+    const MIN_MAX_PERCENTAGE_BUY_LAUNCH: u16 = 50; // 0.5%
 
     #[storage]
     struct Storage {
@@ -75,6 +74,7 @@ mod UnruggableMemecoin {
         launch_time: u64,
         factory_contract: ContractAddress,
         liquidity_type: Option<LiquidityType>,
+        max_percentage_buy_launch: u16,
         // Components.
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
@@ -145,16 +145,18 @@ mod UnruggableMemecoin {
         }
 
         fn set_launched(
-            ref self: ContractState, liquidity_type: LiquidityType, transfer_restriction_delay: u64
+            ref self: ContractState, liquidity_type: LiquidityType, transfer_restriction_delay: u64, max_percentage_buy_launch: u16
         ) {
             self.assert_only_factory();
             assert(!self.is_launched(), errors::ALREADY_LAUNCHED);
+            assert(max_percentage_buy_launch >= MIN_MAX_PERCENTAGE_BUY_LAUNCH, errors::MAX_PERCENTAGE_BUY_LAUNCH_TOO_LOW);
 
             self.liquidity_type.write(Option::Some(liquidity_type));
             self.launch_time.write(get_block_timestamp());
 
             // Enable a transfer limit - until this time has passed,
             // transfers are limited to a certain amount.
+            self.max_percentage_buy_launch.write(max_percentage_buy_launch);
             self.transfer_restriction_delay.write(transfer_restriction_delay);
 
             // renounce ownership
@@ -314,7 +316,7 @@ mod UnruggableMemecoin {
                 }
 
                 assert(
-                    amount <= self.total_supply().percent_mul(MAX_PERCENTAGE_BUY_LAUNCH.into()),
+                    amount <= self.total_supply().percent_mul(self.max_percentage_buy_launch.read().into()),
                     'Max buy cap reached'
                 );
 

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -145,11 +145,17 @@ mod UnruggableMemecoin {
         }
 
         fn set_launched(
-            ref self: ContractState, liquidity_type: LiquidityType, transfer_restriction_delay: u64, max_percentage_buy_launch: u16
+            ref self: ContractState,
+            liquidity_type: LiquidityType,
+            transfer_restriction_delay: u64,
+            max_percentage_buy_launch: u16
         ) {
             self.assert_only_factory();
             assert(!self.is_launched(), errors::ALREADY_LAUNCHED);
-            assert(max_percentage_buy_launch >= MIN_MAX_PERCENTAGE_BUY_LAUNCH, errors::MAX_PERCENTAGE_BUY_LAUNCH_TOO_LOW);
+            assert(
+                max_percentage_buy_launch >= MIN_MAX_PERCENTAGE_BUY_LAUNCH,
+                errors::MAX_PERCENTAGE_BUY_LAUNCH_TOO_LOW
+            );
 
             self.liquidity_type.write(Option::Some(liquidity_type));
             self.launch_time.write(get_block_timestamp());
@@ -316,7 +322,9 @@ mod UnruggableMemecoin {
                 }
 
                 assert(
-                    amount <= self.total_supply().percent_mul(self.max_percentage_buy_launch.read().into()),
+                    amount <= self
+                        .total_supply()
+                        .percent_mul(self.max_percentage_buy_launch.read().into()),
                     'Max buy cap reached'
                 );
 


### PR DESCRIPTION
The max percentage buy limit was hardcoded to 2% before this PR, now it has to be provided during launch, and the value cannot fall behind 0.5%