### PR TITLE
add check token on homepage

### DIFF
--- a/frontend/src/components/ImportTokenModal/style.css.ts
+++ b/frontend/src/components/ImportTokenModal/style.css.ts
@@ -1,3 +1,4 @@
+import { keyframes, style } from '@vanilla-extract/css'
 import { sprinkles } from 'src/theme/css/sprinkles.css'
 
 export const inputLabel = sprinkles({
@@ -10,3 +11,22 @@ export const errorContainer = sprinkles({
   paddingTop: '4',
   color: 'error',
 })
+
+const rotateAnimation = keyframes({
+  '100%': {
+    transform: 'rotate(360deg)',
+  },
+})
+
+export const loader = style([
+  {
+    animation: rotateAnimation,
+    animationDuration: '2s',
+    animationIterationCount: 'infinite',
+    animationTimingFunction: 'linear',
+  },
+  sprinkles({
+    marginLeft: '8',
+    color: 'text1',
+  }),
+])

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -2,6 +2,8 @@ import clsx from 'clsx'
 import { Link } from 'react-router-dom'
 import onlyonstarknet from 'src/assets/onlyonstarknet.png'
 import { PrimaryButton, SecondaryButton } from 'src/components/Button'
+import { ImportTokenModal } from 'src/components/ImportTokenModal'
+import { useImportTokenModal } from 'src/hooks/useModal'
 import Box from 'src/theme/components/Box'
 import { Column, Row } from 'src/theme/components/Flex'
 import * as Text from 'src/theme/components/Text'
@@ -9,33 +11,40 @@ import * as Text from 'src/theme/components/Text'
 import * as styles from './style.css'
 
 export default function HomePage() {
+  // modal
+  const [, toggleImportTokenModel] = useImportTokenModal()
+
   return (
-    <Box className={styles.container}>
-      <Box as="span" className={clsx(styles.backgroundContainer, styles.background)} />
+    <>
+      <Box className={styles.container}>
+        <Box as="span" className={clsx(styles.backgroundContainer, styles.background)} />
 
-      <Column className={styles.titleContainer}>
-        <Text.Custom as="h1" className={styles.title}>
-          Unruggable Meme
-        </Text.Custom>
-        <Box as="img" src={onlyonstarknet} className={styles.subtitle} />
-      </Column>
+        <Column className={styles.titleContainer}>
+          <Text.Custom as="h1" className={styles.title}>
+            Unruggable Meme
+          </Text.Custom>
+          <Box as="img" src={onlyonstarknet} className={styles.subtitle} />
+        </Column>
 
-      <Column as="article" className={styles.firstArticle}>
-        <Text.Custom className={styles.firstArticleText}>
-          Tired of getting rugpulled? Introducing Unruggable Meme, a memecoin standard and deployment tool designed to
-          ensure a maximum safety for memecoin traders.
-        </Text.Custom>
+        <Column as="article" className={styles.firstArticle}>
+          <Text.Custom className={styles.firstArticleText}>
+            Tired of getting rugpulled? Introducing Unruggable Meme, a memecoin standard and deployment tool designed to
+            ensure a maximum safety for memecoin traders.
+          </Text.Custom>
 
-        <Row gap="16" className={styles.buttonContainer}>
-          <Link to="/deploy">
-            <PrimaryButton className={styles.firstArticleButton}>Deploy</PrimaryButton>
-          </Link>
+          <Row gap="16" className={styles.buttonContainer}>
+            <Link to="/deploy">
+              <PrimaryButton className={styles.firstArticleButton}>Deploy</PrimaryButton>
+            </Link>
 
-          <Link to="/manage">
-            <SecondaryButton className={styles.firstArticleButton}>Check token</SecondaryButton>
-          </Link>
-        </Row>
-      </Column>
-    </Box>
+            <SecondaryButton className={styles.firstArticleButton} onClick={toggleImportTokenModel}>
+              Check token
+            </SecondaryButton>
+          </Row>
+        </Column>
+      </Box>
+
+      <ImportTokenModal />
+    </>
   )
 }

--- a/frontend/src/pages/Launch/index.tsx
+++ b/frontend/src/pages/Launch/index.tsx
@@ -96,7 +96,7 @@ export default function LaunchPage() {
         </Column>
       </Section>
 
-      <ImportTokenModal />
+      <ImportTokenModal save />
     </>
   )
 }


### PR DESCRIPTION
The "Check Token" button located on the homepage opens a modal, prompting the user to input a token address. If the entered address corresponds to an unruggable memecoin, the user will be redirected to the token's page. Otherwise, an error message will be displayed.