### PR TITLE
audit: remove factory owner

### DIFF
--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -7,8 +7,6 @@ mod Factory {
     use core::starknet::event::EventEmitter;
     use core::zeroable::Zeroable;
     use ekubo::types::i129::i129;
-    use openzeppelin::access::ownable::OwnableComponent;
-    use openzeppelin::access::ownable::ownable::OwnableComponent::InternalTrait;
     use openzeppelin::token::erc20::interface::{
         IERC20, ERC20ABIDispatcher, ERC20ABIDispatcherTrait
     };
@@ -29,17 +27,11 @@ mod Factory {
         IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
     };
 
-    // Components.
-    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
-    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
-
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
         MemecoinCreated: MemecoinCreated,
         MemecoinLaunched: MemecoinLaunched,
-        #[flat]
-        OwnableEvent: OwnableComponent::Event
     }
 
     #[derive(Drop, starknet::Event)]
@@ -64,20 +56,15 @@ mod Factory {
         exchange_configs: LegacyMap<SupportedExchanges, ContractAddress>,
         deployed_memecoins: LegacyMap<ContractAddress, bool>,
         lock_manager_address: ContractAddress,
-        // Components.
-        #[substorage(v0)]
-        ownable: OwnableComponent::Storage,
     }
 
     #[constructor]
     fn constructor(
         ref self: ContractState,
-        owner: ContractAddress,
         memecoin_class_hash: ClassHash,
         lock_manager_address: ContractAddress,
         mut exchanges: Span<(SupportedExchanges, ContractAddress)>
     ) {
-        self.ownable.initializer(owner);
         self.memecoin_class_hash.write(memecoin_class_hash);
         self.lock_manager_address.write(lock_manager_address);
 

--- a/contracts/src/tests/fork_tests/utils.cairo
+++ b/contracts/src/tests/fork_tests/utils.cairo
@@ -63,18 +63,11 @@ fn deploy_ekubo_launcher() -> ContractAddress {
 
 // MemeFactory
 fn deploy_meme_factory(exchanges: Span<(SupportedExchanges, ContractAddress)>) -> ContractAddress {
-    deploy_meme_factory_with_owner(OWNER(), exchanges)
-}
-
-fn deploy_meme_factory_with_owner(
-    owner: ContractAddress, exchanges: Span<(SupportedExchanges, ContractAddress)>
-) -> ContractAddress {
     let memecoin_class_hash = declare('UnruggableMemecoin').class_hash;
     let lock_manager_address = deploy_locker();
 
     let contract = declare('Factory');
     let mut calldata = array![];
-    Serde::serialize(@owner, ref calldata);
     Serde::serialize(@memecoin_class_hash, ref calldata);
     Serde::serialize(@lock_manager_address, ref calldata);
     Serde::serialize(@exchanges.into(), ref calldata);

--- a/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
+++ b/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
@@ -29,7 +29,7 @@ mod test_constructor {
     use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank, CheatTarget};
     use starknet::{ContractAddress, contract_address_const};
     use unruggable::tests::unit_tests::utils::{
-        deploy_jedi_amm_factory_and_router, deploy_meme_factory_with_owner, deploy_locker,
+        deploy_jedi_amm_factory_and_router, deploy_meme_factory, deploy_locker,
         deploy_eth_with_owner, OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, INITIAL_HOLDERS,
         INITIAL_HOLDER_1, INITIAL_HOLDER_2, INITIAL_HOLDERS_AMOUNTS, SALT, DefaultTxInfoMock,
         deploy_memecoin_through_factory, ETH_ADDRESS, deploy_memecoin_through_factory_with_owner,
@@ -156,7 +156,7 @@ mod memecoin_entrypoints {
     use unruggable::exchanges::{SupportedExchanges};
     use unruggable::factory::{IFactory, IFactoryDispatcher, IFactoryDispatcherTrait};
     use unruggable::tests::unit_tests::utils::{
-        deploy_jedi_amm_factory_and_router, deploy_meme_factory_with_owner, deploy_locker,
+        deploy_jedi_amm_factory_and_router, deploy_meme_factory, deploy_locker,
         deploy_eth_with_owner, OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, INITIAL_HOLDERS,
         INITIAL_HOLDER_1, INITIAL_HOLDER_2, INITIAL_HOLDERS_AMOUNTS, SALT, DefaultTxInfoMock,
         deploy_memecoin_through_factory, ETH_ADDRESS, deploy_memecoin_through_factory_with_owner,
@@ -276,7 +276,7 @@ mod memecoin_internals {
     use starknet::{ContractAddress, contract_address_const};
     use super::{TxInfoMock};
     use unruggable::tests::unit_tests::utils::{
-        deploy_jedi_amm_factory_and_router, deploy_meme_factory_with_owner, deploy_locker,
+        deploy_jedi_amm_factory_and_router, deploy_meme_factory, deploy_locker,
         deploy_eth_with_owner, OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, INITIAL_HOLDERS,
         INITIAL_HOLDER_1, INITIAL_HOLDER_2, INITIAL_HOLDERS_AMOUNTS, SALT, DefaultTxInfoMock,
         deploy_memecoin_through_factory, ETH_ADDRESS, deploy_memecoin_through_factory_with_owner,

--- a/contracts/src/tests/unit_tests/utils.cairo
+++ b/contracts/src/tests/unit_tests/utils.cairo
@@ -165,12 +165,6 @@ fn deploy_jedi_amm_factory_and_router() -> (ContractAddress, ContractAddress) {
 
 // MemeFactory
 fn deploy_meme_factory(router_address: ContractAddress) -> ContractAddress {
-    deploy_meme_factory_with_owner(OWNER(), router_address)
-}
-
-fn deploy_meme_factory_with_owner(
-    owner: ContractAddress, router_address: ContractAddress
-) -> ContractAddress {
     let locker_address = deploy_locker();
     let memecoin_class_hash = declare('UnruggableMemecoin').class_hash;
 
@@ -181,7 +175,6 @@ fn deploy_meme_factory_with_owner(
 
     let contract = declare('Factory');
     let mut calldata = array![];
-    Serde::serialize(@owner, ref calldata);
     Serde::serialize(@memecoin_class_hash, ref calldata);
     Serde::serialize(@locker_address, ref calldata);
     Serde::serialize(@amms.into(), ref calldata);


### PR DESCRIPTION
As reported in the audit by
@credence0x - [U-04]
@0xEniotna - [O-03]
@ermvrs - [I-02]

The factory uses the Ownable component and takes an owner upon deployment, which is not required.

Mitigation:
- Removed the ownable component
- Removed the owner constructor argument.
 