### PR TITLE
audit: remove unused variables

### DIFF
--- a/contracts/src/exchanges/ekubo/ekubo_adapter.cairo
+++ b/contracts/src/exchanges/ekubo/ekubo_adapter.cairo
@@ -57,7 +57,6 @@ impl EkuboAdapterImpl of unruggable::exchanges::ExchangeAdapter<
         };
 
         let this = get_contract_address();
-        let caller_address = starknet::get_caller_address();
         let memecoin = IUnruggableMemecoinDispatcher { contract_address: token_address, };
         let memecoin_address = memecoin.contract_address;
         let quote_token = ERC20ABIDispatcher { contract_address: quote_address, };

--- a/contracts/src/exchanges/jediswap_adapter.cairo
+++ b/contracts/src/exchanges/jediswap_adapter.cairo
@@ -91,7 +91,6 @@ impl JediswapAdapterImpl of unruggable::exchanges::ExchangeAdapter<
         let memecoin_balance = memecoin.balanceOf(this);
         memecoin.approve(jedi_router.contract_address, memecoin_balance);
         quote_token.approve(jedi_router.contract_address, quote_amount);
-        let quote_balance = quote_token.balanceOf(this);
 
         // As we're supplying the first liquidity for this pool,
         // The expected minimum amounts for each tokens are the amounts we're supplying.

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -134,7 +134,6 @@ mod Factory {
             let memecoin = IUnruggableMemecoinDispatcher { contract_address: memecoin_address };
             let caller_address = get_caller_address();
             let router_address = self.exchange_address(SupportedExchanges::Jediswap);
-            let quote_token = ERC20ABIDispatcher { contract_address: quote_address };
             assert(!memecoin.is_launched(), errors::ALREADY_LAUNCHED);
             assert(caller_address == memecoin.owner(), errors::CALLER_NOT_OWNER);
             assert(router_address.is_non_zero(), errors::EXCHANGE_ADDRESS_ZERO);
@@ -176,7 +175,6 @@ mod Factory {
         ) -> (u64, EkuboLP) {
             let memecoin = IUnruggableMemecoinDispatcher { contract_address: memecoin_address };
             let launchpad_address = self.exchange_address(SupportedExchanges::Ekubo);
-            let quote_token = ERC20ABIDispatcher { contract_address: quote_address };
             let caller_address = get_caller_address();
             assert(caller_address == memecoin.owner(), errors::CALLER_NOT_OWNER);
             assert(launchpad_address.is_non_zero(), errors::EXCHANGE_ADDRESS_ZERO);


### PR DESCRIPTION
As reported in the audit by
@credence0x - [U-05]
@ermvrs - [BP-02] / [BP-06] / [BP-07]

- The variable `quote_balance` was not used
- The variables `quote_token` were not used
- The variable `caller_address` was not used

Mitigation:

Removed the variables.