### PR TITLE
audit: remove duplicated 'is_launched' check

### DIFF
--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -138,7 +138,6 @@ mod Factory {
             assert(!memecoin.is_launched(), errors::ALREADY_LAUNCHED);
             assert(caller_address == memecoin.owner(), errors::CALLER_NOT_OWNER);
             assert(router_address.is_non_zero(), errors::EXCHANGE_ADDRESS_ZERO);
-            assert(!memecoin.is_launched(), errors::ALREADY_LAUNCHED);
 
             let mut pair_address = jediswap_adapter::JediswapAdapterImpl::create_and_add_liquidity(
                 exchange_address: router_address,


### PR DESCRIPTION
As reported in the audit by
@credence0x - [U-03]
@0xEniotna - [O-04]
@ermvrs - [BP-05]

The `is_launched` check was duplicated

Mitigation:

Removed the second useless check.