### PR TITLE
audit: remove useless zero check

### DIFF
--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -454,9 +454,7 @@ mod UnruggableMemecoin {
         ) {
             // If this is not a mint and the sender will no longer hold tokens after the transfer,
             // decrement the holders count.
-            //TODO(audit): verify whether sender can _actually_ be zero - as this function is called from _transfer,
-            // which is supposedly not called from the zero address.
-            if sender.is_non_zero() && self.balanceOf(sender) == amount {
+            if self.balanceOf(sender) == amount {
                 let current_holders_count = self.pre_launch_holders_count.read();
 
                 self.pre_launch_holders_count.write(current_holders_count - 1);


### PR DESCRIPTION
As reported in the audit by
@credence0x - [U-01]
@0xEniotna - [O-01]

The zero address check is useless since the token can’t be minted to the zero address, can’t be burned and can’t be transferred to the zero address, the sender address would never be 0.

Mitigation:

Removed the check for `self.is_zero()`