### PR TITLE
audit: remove unnecessary write

### DIFF
--- a/contracts/src/locker/lock_manager.cairo
+++ b/contracts/src/locker/lock_manager.cairo
@@ -157,7 +157,6 @@ mod LockManager {
 
             assert(amount_to_increase != 0, errors::ZERO_AMOUNT);
             let mut token_lock = self.locks.read(lock_address);
-            self.locks.write(lock_address, token_lock);
 
             ERC20ABIDispatcher { contract_address: token_lock.token }
                 .transferFrom(get_caller_address(), lock_address, amount_to_increase);


### PR DESCRIPTION
As reported in the audit by
@ermvrs  - [BP-04]
@0xEniotna - [L-01]
The write is sequential to the read without any variable mutation, and thus is unnecessary.

Mitigation:

Removed the read and write.