### PR TITLE
audit: prevent memecoin owner to be zero

### DIFF
--- a/contracts/src/errors.cairo
+++ b/contracts/src/errors.cairo
@@ -4,6 +4,7 @@ const MAX_TEAM_ALLOCATION_REACHED: felt252 = 'Max team allocation reached';
 const EXCHANGE_NOT_SUPPORTED: felt252 = 'Exchange not supported';
 const EXCHANGE_ADDRESS_ZERO: felt252 = 'Exchange address is zero';
 const RECIPIENT_ADDRESS_ZERO: felt252 = 'recipient address is zero';
+const OWNER_IS_ZERO: felt252 = 'Owner is zero';
 const NOT_FACTORY: felt252 = 'Caller not factory';
 const CALLER_NOT_OWNER: felt252 = 'Caller is not the owner';
 const ALREADY_LAUNCHED: felt252 = 'Already launched';

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -114,6 +114,7 @@ mod UnruggableMemecoin {
         initial_holders: Span<ContractAddress>,
         initial_holders_amounts: Span<u256>,
     ) {
+        assert(owner.is_non_zero(), errors::OWNER_IS_ZERO);
         self.erc20.initializer(name, symbol);
 
         self.ownable.initializer(owner);


### PR DESCRIPTION
As reported in the audit by
@credence0x  - [M-01]

The owner of the memecoin could be zero.

Mitigation:

Add a non-zero check