### PR TITLE
audit: count unique holders at launch

### DIFF
--- a/contracts/src/tests/unit_tests.cairo
+++ b/contracts/src/tests/unit_tests.cairo
@@ -2,5 +2,6 @@ mod test_factory;
 mod test_lock_manager;
 mod test_memecoin_erc20;
 mod test_unruggable_memecoin;
+mod test_utils;
 
 mod utils;

--- a/contracts/src/tests/unit_tests/test_utils.cairo
+++ b/contracts/src/tests/unit_tests/test_utils.cairo
@@ -1,0 +1,7 @@
+use unruggable::utils::unique_count;
+#[test]
+fn test_unique_count() {
+    let elems: Array<u128> = array![1, 2, 2, 3, 4, 4, 5, 6];
+    let count = unique_count(elems.span());
+    assert_eq!(count, 6)
+}

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -41,6 +41,7 @@ mod UnruggableMemecoin {
         IUnruggableMemecoinSnake, IUnruggableMemecoinCamel, IUnruggableAdditional
     };
     use unruggable::utils::math::PercentageMath;
+    use unruggable::utils::unique_count;
 
     // Components.
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -408,7 +409,7 @@ mod UnruggableMemecoin {
                 i += 1;
             };
             self.team_allocation.write(team_allocation);
-            self.pre_launch_holders_count.write(initial_holders.len().try_into().unwrap());
+            self.pre_launch_holders_count.write(unique_count(initial_holders).try_into().unwrap());
 
             team_allocation
         }

--- a/contracts/src/utils.cairo
+++ b/contracts/src/utils.cairo
@@ -1,4 +1,5 @@
 mod math;
+use core::num::traits::{One};
 use integer::u256_from_felt252;
 use starknet::ContractAddress;
 
@@ -21,4 +22,23 @@ impl ContractAddressOrder of PartialOrd<ContractAddress> {
     fn gt(lhs: ContractAddress, rhs: ContractAddress) -> bool {
         u256_from_felt252(lhs.into()) > u256_from_felt252(rhs.into())
     }
+}
+
+fn unique_count<T, +Copy<T>, +Drop<T>, +PartialEq<T>, +Into<T, felt252>>(mut self: Span<T>) -> u32 {
+    let mut dict: Felt252Dict<felt252> = Default::default();
+    let mut counter = 0;
+    loop {
+        match self.pop_front() {
+            Option::Some(value) => {
+                let value: felt252 = (*value).into();
+                if dict.get(value).is_one() {
+                    continue;
+                }
+                dict.insert(value, One::one());
+                counter += 1;
+            },
+            Option::None => { break; }
+        }
+    };
+    counter
 }

--- a/contracts/src/utils.cairo
+++ b/contracts/src/utils.cairo
@@ -24,21 +24,31 @@ impl ContractAddressOrder of PartialOrd<ContractAddress> {
     }
 }
 
-fn unique_count<T, +Copy<T>, +Drop<T>, +PartialEq<T>, +Into<T, felt252>>(mut self: Span<T>) -> u32 {
-    let mut dict: Felt252Dict<felt252> = Default::default();
+fn unique_count<T, +Copy<T>, +Drop<T>, +PartialEq<T>>(mut self: Span<T>) -> u32 {
     let mut counter = 0;
+    let mut result: Array<T> = array![];
     loop {
         match self.pop_front() {
             Option::Some(value) => {
-                let value: felt252 = (*value).into();
-                if dict.get(value).is_one() {
+                if contains(result.span(), *value) {
                     continue;
                 }
-                dict.insert(value, One::one());
+                result.append(*value);
                 counter += 1;
             },
             Option::None => { break; }
         }
     };
     counter
+}
+
+fn contains<T, +Copy<T>, +Drop<T>, +PartialEq<T>>(mut self: Span<T>, value: T) -> bool {
+    loop {
+        match self.pop_front() {
+            Option::Some(current) => { if *current == value {
+                break true;
+            } },
+            Option::None => { break false; }
+        }
+    }
 }


### PR DESCRIPTION
As reported in the audit by
@ermvrs  - [I-01]
@credence0x - [H-02]

The number of initial holders can be gamed by supplying multiple times the same address

Mitigation:

Add a `unique` function that returns the count of unique occurences in an array.