### PR TITLE
audit: disable launch non-unruggable coins

### DIFF
--- a/contracts/src/errors.cairo
+++ b/contracts/src/errors.cairo
@@ -9,3 +9,4 @@ const CALLER_NOT_OWNER: felt252 = 'Caller is not the owner';
 const ALREADY_LAUNCHED: felt252 = 'Already launched';
 const PRICE_ZERO: felt252 = 'Starting tick cannot be 0';
 const MAX_PERCENTAGE_BUY_LAUNCH_TOO_LOW: felt252 = 'Max percentage buy too low';
+const NOT_UNRUGGABLE: felt252 = 'Token not deployed by factory';

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -131,6 +131,7 @@ mod Factory {
             quote_amount: u256,
             unlock_time: u64,
         ) -> ContractAddress {
+            assert(self.is_memecoin(memecoin_address), errors::NOT_UNRUGGABLE);
             let memecoin = IUnruggableMemecoinDispatcher { contract_address: memecoin_address };
             let caller_address = get_caller_address();
             let router_address = self.exchange_address(SupportedExchanges::Jediswap);
@@ -174,6 +175,7 @@ mod Factory {
             quote_address: ContractAddress,
             ekubo_parameters: EkuboPoolParameters,
         ) -> (u64, EkuboLP) {
+            assert(self.is_memecoin(memecoin_address), errors::NOT_UNRUGGABLE);
             let memecoin = IUnruggableMemecoinDispatcher { contract_address: memecoin_address };
             let launchpad_address = self.exchange_address(SupportedExchanges::Ekubo);
             let quote_token = ERC20ABIDispatcher { contract_address: quote_address };

--- a/contracts/src/tests/unit_tests/utils.cairo
+++ b/contracts/src/tests/unit_tests/utils.cairo
@@ -2,7 +2,7 @@ use core::traits::TryInto;
 use openzeppelin::token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
 use snforge_std::{
     ContractClass, ContractClassTrait, CheatTarget, declare, start_prank, stop_prank, TxInfoMock,
-    start_warp, stop_warp
+    start_warp, stop_warp, get_class_hash
 };
 use starknet::ContractAddress;
 use unruggable::exchanges::{SupportedExchanges};
@@ -212,6 +212,19 @@ fn deploy_eth_with_owner(owner: ContractAddress) -> (ERC20ABIDispatcher, Contrac
     Serde::serialize(@owner, ref calldata);
 
     let address = token.deploy_at(@calldata, ETH_ADDRESS()).unwrap();
+    let dispatcher = ERC20ABIDispatcher { contract_address: address, };
+    (dispatcher, address)
+}
+
+fn deploy_token_from_class_at_address_with_owner(
+    owner: ContractAddress, address: ContractAddress, class_address: ContractAddress
+) -> (ERC20ABIDispatcher, ContractAddress) {
+    let token = ContractClass { class_hash: get_class_hash(class_address) };
+    let mut calldata = Default::default();
+    Serde::serialize(@DEFAULT_INITIAL_SUPPLY(), ref calldata);
+    Serde::serialize(@owner, ref calldata);
+
+    let address = token.deploy_at(@calldata, address).unwrap();
     let dispatcher = ERC20ABIDispatcher { contract_address: address, };
     (dispatcher, address)
 }


### PR DESCRIPTION
As reported in the audit by
@ermvrs - [L-01]

The factory could be used to launch tokens not created by the factory. If the token has the correct entrypoints, the call would not revert.

Mitigation:

Add a check to ensure the memecoin is an unruggable one.