### PR TITLE
audit: fix jediswap launch when the pair exists

### DIFF
--- a/contracts/src/exchanges/ekubo/launcher.cairo
+++ b/contracts/src/exchanges/ekubo/launcher.cairo
@@ -38,15 +38,6 @@ struct EkuboLP {
     bounds: Bounds,
 }
 
-fn sort_tokens(
-    tokenA: ContractAddress, tokenB: ContractAddress
-) -> (ContractAddress, ContractAddress) {
-    if tokenA < tokenB {
-        (tokenA, tokenB)
-    } else {
-        (tokenB, tokenA)
-    }
-}
 
 #[starknet::interface]
 trait IEkuboLauncher<T> {
@@ -163,7 +154,7 @@ mod EkuboLauncher {
     use openzeppelin::token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
     use starknet::SyscallResultTrait;
     use starknet::{ContractAddress, ClassHash, get_contract_address, get_caller_address, Store};
-    use super::{IEkuboLauncher, EkuboLaunchParameters, sort_tokens};
+    use super::{IEkuboLauncher, EkuboLaunchParameters};
     use super::{StorableBounds, StorablePoolKey, StorableEkuboLP, EkuboLP};
     use unruggable::errors;
     use unruggable::exchanges::ekubo::errors::{NOT_POSITION_OWNER};
@@ -175,6 +166,7 @@ mod EkuboLauncher {
         IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
     };
     use unruggable::utils::math::PercentageMath;
+    use unruggable::utils::sort_tokens;
 
 
     #[storage]

--- a/contracts/src/exchanges/jediswap_adapter.cairo
+++ b/contracts/src/exchanges/jediswap_adapter.cairo
@@ -82,7 +82,13 @@ impl JediswapAdapterImpl of unruggable::exchanges::ExchangeAdapter<
         let jedi_router = IJediswapRouterDispatcher { contract_address: exchange_address };
         assert(jedi_router.contract_address.is_non_zero(), errors::EXCHANGE_ADDRESS_ZERO);
         let jedi_factory = IJediswapFactoryDispatcher { contract_address: jedi_router.factory(), };
-        let pair_address = jedi_factory.create_pair(quote_address, memecoin_address);
+
+        let existing_pair_address = jedi_factory.get_pair(memecoin_address, quote_address);
+        let pair_address = if existing_pair_address.is_non_zero() {
+            existing_pair_address
+        } else {
+            jedi_factory.create_pair(memecoin_address, quote_address)
+        };
 
         // Add liquidity - approve the entirety of the memecoin and quote token balances
         // to supply as liquidity

--- a/contracts/src/exchanges/jediswap_adapter.cairo
+++ b/contracts/src/exchanges/jediswap_adapter.cairo
@@ -83,13 +83,6 @@ impl JediswapAdapterImpl of unruggable::exchanges::ExchangeAdapter<
         assert(jedi_router.contract_address.is_non_zero(), errors::EXCHANGE_ADDRESS_ZERO);
         let jedi_factory = IJediswapFactoryDispatcher { contract_address: jedi_router.factory(), };
 
-        let existing_pair_address = jedi_factory.get_pair(memecoin_address, quote_address);
-        let pair_address = if existing_pair_address.is_non_zero() {
-            existing_pair_address
-        } else {
-            jedi_factory.create_pair(memecoin_address, quote_address)
-        };
-
         // Add liquidity - approve the entirety of the memecoin and quote token balances
         // to supply as liquidity
         // Transfer from caller to this contract so that jediswap can take the tokens from here
@@ -111,11 +104,8 @@ impl JediswapAdapterImpl of unruggable::exchanges::ExchangeAdapter<
                 this, // receiver of LP tokens is the factory, that instantly locks them
                 deadline: get_block_timestamp()
             );
-        assert(memecoin.balanceOf(pair_address) == memecoin_balance, 'add liquidity meme failed');
-        assert(quote_token.balanceOf(pair_address) == quote_amount, 'add liq quote failed');
+        let pair_address = jedi_factory.get_pair(memecoin_address, quote_address);
         let pair = ERC20ABIDispatcher { contract_address: pair_address, };
-
-        assert(pair.balanceOf(this) == liquidity_received, 'wrong LP tkns amount');
 
         // Lock LP tokens
         let lock_manager = ILockManagerDispatcher { contract_address: lock_manager_address };
@@ -127,7 +117,6 @@ impl JediswapAdapterImpl of unruggable::exchanges::ExchangeAdapter<
                 unlock_time: unlock_time,
                 withdrawer: caller_address,
             );
-        assert(pair.balanceOf(locked_address) == liquidity_received, 'lock failed');
 
         pair.contract_address
     }

--- a/contracts/src/utils.cairo
+++ b/contracts/src/utils.cairo
@@ -52,3 +52,13 @@ fn contains<T, +Copy<T>, +Drop<T>, +PartialEq<T>>(mut self: Span<T>, value: T) -
         }
     }
 }
+
+fn sort_tokens(
+    tokenA: ContractAddress, tokenB: ContractAddress
+) -> (ContractAddress, ContractAddress) {
+    if tokenA < tokenB {
+        (tokenA, tokenB)
+    } else {
+        (tokenB, tokenA)
+    }
+}


### PR DESCRIPTION
As reported in the audit by
@credence0x  - [C-01]

The problem was that if someone calls `create_pair` with the addresses of the memecoin and quote token, (not necessarily adding liquidity, just creating the pair), then the `launch_on_jediswap` call would fail as the pair already existed.

Also, the assertions on the balanceOf the pair could be gamed by a malicious actor that would send tokens to the pair so that it's un-launchable.

Mitigation:

- Remove `create_pair` call
- query `get_pair` to get the pair address
- Remove assertions on balanceOf pair.