### PR TITLE
audit: fix buy restriction on jediswap

### DIFF
--- a/contracts/src/tests/fork_tests/test_jediswap.cairo
+++ b/contracts/src/tests/fork_tests/test_jediswap.cairo
@@ -96,3 +96,53 @@ fn test_jediswap_integration() {
 
     assert(token_lock == expected_lock, 'token lock details wrong');
 }
+
+#[test]
+#[fork("Mainnet")]
+#[should_panic(expected: ('Max buy cap reached',))]
+fn test_buy_above_max_limit_should_fail() {
+    //* Setup
+    let owner = snforge_std::test_address();
+    let (memecoin, memecoin_address) = deploy_memecoin_through_factory_with_owner(owner);
+    let (quote, quote_address) = deploy_eth_with_owner(owner);
+    let router = IJediswapRouterDispatcher { contract_address: JEDI_ROUTER_ADDRESS() };
+    let factory = IFactoryDispatcher { contract_address: MEMEFACTORY_ADDRESS() };
+
+    let unlock_time = starknet::get_block_timestamp() + DEFAULT_MIN_LOCKTIME;
+
+    // approve spending of eth by factory
+    let amount: u256 = 1 * pow_256(10, 18); // 1 ETHER
+    start_prank(CheatTarget::One(quote.contract_address), owner);
+    quote.approve(factory.contract_address, amount);
+    stop_prank(CheatTarget::One(quote.contract_address));
+
+    let pair_address = factory
+        .launch_on_jediswap(
+            memecoin_address,
+            TRANSFER_RESTRICTION_DELAY,
+            MAX_PERCENTAGE_BUY_LAUNCH,
+            quote_address,
+            amount,
+            unlock_time
+        );
+
+    let pair = IJediswapPairDispatcher { contract_address: pair_address };
+
+    // * Test
+
+    // Approve required token amounts
+    start_prank(CheatTarget::One(quote.contract_address), owner);
+    quote.approve(JEDI_ROUTER_ADDRESS(), 1 * pow_256(10, 18));
+    stop_prank(CheatTarget::One(quote.contract_address));
+
+    let amount_in = 2 * pow_256(10, 17); // @audit Bigger amount
+    start_prank(CheatTarget::One(router.contract_address), owner);
+    let first_swap = router
+        .swap_exact_tokens_for_tokens(
+            amountIn: amount_in,
+            amountOutMin: 0,
+            path: array![quote_address, memecoin_address],
+            to: owner,
+            deadline: starknet::get_block_timestamp()
+        );
+}

--- a/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
+++ b/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
@@ -194,8 +194,7 @@ mod memecoin_entrypoints {
     }
 
     #[test]
-    #[should_panic(expected: ('Max buy cap reached',))]
-    fn test_transfer_max_percentage() {
+    fn test_transfer_max_percentage_not_pair_should_succeed() {
         let (memecoin, memecoin_address) = deploy_and_launch_memecoin();
 
         // Transfer slightly more than 2% of 21M stokens from owner to ALICE().
@@ -205,22 +204,21 @@ mod memecoin_entrypoints {
     }
 
     #[test]
-    #[should_panic(expected: ('Max buy cap reached',))]
-    fn test_transfer_from_max_percentage() {
+    fn test_transfer_from_max_percentage_not_pair_should_succeed() {
         let (memecoin, memecoin_address) = deploy_and_launch_memecoin();
 
+        let this_address = snforge_std::test_address();
         let amount = 420_001 * pow_256(10, 18);
 
-        start_prank(CheatTarget::One(memecoin.contract_address), OWNER());
-        memecoin.approve(snforge_std::test_address(), amount);
+        start_prank(CheatTarget::One(memecoin.contract_address), INITIAL_HOLDER_1());
+        memecoin.approve(this_address, amount);
         stop_prank(CheatTarget::One(memecoin.contract_address));
 
-        memecoin.transfer_from(OWNER(), ALICE(), amount);
+        memecoin.transfer_from(INITIAL_HOLDER_1(), ALICE(), amount);
     }
 
     #[test]
-    #[should_panic(expected: ('Multi calls not allowed',))]
-    fn test_transfer_from_multi_call() {
+    fn test_transfer_from_multi_call_not_pair_should_succeed() {
         let (memecoin, memecoin_address) = deploy_and_launch_memecoin();
 
         let this_address = snforge_std::test_address();

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -321,7 +321,8 @@ mod UnruggableMemecoin {
                 // The LP pair must be whitelisted from transfer restrictions
                 match liquidity_type {
                     LiquidityType::ERC20(pair) => {
-                        if (get_caller_address() == pair || recipient == pair) {
+                        if (get_caller_address() != pair) {
+                            // If it's not a buy transaction, we return early
                             return;
                         }
                     },


### PR DESCRIPTION
As reported by 
- @0xEniotna [C-01],
- @ermvrs [M-01]

The `get_caller_address() == pair` condition is true when the transaction is a BUY, hence the buy limits were never enforced.

Fix:
 - return early only if `get_caller_address() != pair`, meaning that it's not a buy tx.