### PR TITLE
audit: fix aggregator support

### DIFF
--- a/contracts/src/factory/interface.cairo
+++ b/contracts/src/factory/interface.cairo
@@ -147,4 +147,7 @@ trait IFactory<TContractState> {
     ///
     /// * `bool` - Returns true if the address is a memecoin, false otherwise.
     fn is_memecoin(self: @TContractState, address: ContractAddress) -> bool;
+
+    /// Returns the address of Ekubo Core, registered inside the EkuboLauncher contract.
+    fn ekubo_core_address(self: @TContractState) -> ContractAddress;
 }

--- a/contracts/src/tests/fork_tests/test_jediswap.cairo
+++ b/contracts/src/tests/fork_tests/test_jediswap.cairo
@@ -1,6 +1,6 @@
 use debug::PrintTrait;
 use openzeppelin::token::erc20::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
-use snforge_std::{start_prank, stop_prank, CheatTarget};
+use snforge_std::{start_prank, stop_prank, CheatTarget, TxInfoMockTrait, start_spoof, stop_spoof};
 use unruggable::exchanges::SupportedExchanges;
 use unruggable::exchanges::jediswap_adapter::{
     IJediswapFactoryDispatcher, IJediswapFactoryDispatcherTrait, IJediswapRouterDispatcher,
@@ -19,83 +19,89 @@ use unruggable::token::interface::{IUnruggableMemecoinDispatcherTrait};
 use unruggable::token::memecoin::LiquidityType;
 use unruggable::utils::math::PercentageMath;
 
-#[test]
-#[fork("Mainnet")]
-fn test_jediswap_integration() {
-    let owner = snforge_std::test_address();
-    let (memecoin, memecoin_address) = deploy_memecoin_through_factory_with_owner(owner);
-    let (quote, quote_address) = deploy_eth_with_owner(owner);
-    let router = IJediswapRouterDispatcher { contract_address: JEDI_ROUTER_ADDRESS() };
-    let factory = IFactoryDispatcher { contract_address: MEMEFACTORY_ADDRESS() };
+//TODO! This test cannot pass due to a bug in starknet foundry
+// when mocking the tx_hash during interactions with Cairo0 contracts.
+// #[test]
+// #[fork("Mainnet")]
+// fn test_jediswap_integration() {
+//     let owner = snforge_std::test_address();
+//     let (memecoin, memecoin_address) = deploy_memecoin_through_factory_with_owner(owner);
+//     let (quote, quote_address) = deploy_eth_with_owner(owner);
+//     let router = IJediswapRouterDispatcher { contract_address: JEDI_ROUTER_ADDRESS() };
+//     let factory = IFactoryDispatcher { contract_address: MEMEFACTORY_ADDRESS() };
+//     // Test that swaps work correctly
+//     // Mock the txInfo, as the base tx_hash_tracker value is 0
+//     // and will thus prevent this transaction
+//     let mut tx_info = TxInfoMockTrait::default();
+//     tx_info.transaction_hash = Option::Some(1234);
+//     start_spoof(CheatTarget::All, tx_info);
 
-    let unlock_time = starknet::get_block_timestamp() + DEFAULT_MIN_LOCKTIME;
+//     let unlock_time = starknet::get_block_timestamp() + DEFAULT_MIN_LOCKTIME;
 
-    // approve spending of eth by factory
-    let amount: u256 = 1 * pow_256(10, 18); // 1 ETHER
-    start_prank(CheatTarget::One(quote.contract_address), owner);
-    quote.approve(factory.contract_address, amount);
-    stop_prank(CheatTarget::One(quote.contract_address));
+//     // approve spending of eth by factory
+//     let amount: u256 = 1 * pow_256(10, 18); // 1 ETHER
+//     start_prank(CheatTarget::One(quote.contract_address), owner);
+//     quote.approve(factory.contract_address, amount);
+//     stop_prank(CheatTarget::One(quote.contract_address));
 
-    let pair_address = factory
-        .launch_on_jediswap(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            quote_address,
-            amount,
-            unlock_time
-        );
+//     let pair_address = factory
+//         .launch_on_jediswap(
+//             memecoin_address,
+//             TRANSFER_RESTRICTION_DELAY,
+//             MAX_PERCENTAGE_BUY_LAUNCH,
+//             quote_address,
+//             amount,
+//             unlock_time
+//         );
 
-    let pair = IJediswapPairDispatcher { contract_address: pair_address };
+//     let pair = IJediswapPairDispatcher { contract_address: pair_address };
 
-    // Test that swaps work correctly
+//     // Approve required token amounts
+//     start_prank(CheatTarget::One(quote.contract_address), owner);
+//     quote.approve(JEDI_ROUTER_ADDRESS(), 1 * pow_256(10, 18));
+//     stop_prank(CheatTarget::One(quote.contract_address));
 
-    // Approve required token amounts
-    start_prank(CheatTarget::One(quote.contract_address), owner);
-    quote.approve(JEDI_ROUTER_ADDRESS(), 1 * pow_256(10, 18));
-    stop_prank(CheatTarget::One(quote.contract_address));
+//     // Max buy cap is `MAX_PERCENTAGE_BUY_LAUNCH` of total supply
+//     // Initial rate is roughly 1 ETH for 21M meme,
+//     // so if max buy is ~ 2% of 1 ETH = 0.02 ETH
+//     let amount_in = MAX_PERCENTAGE_BUY_LAUNCH.into() * pow_256(10, 14);
+//     start_prank(CheatTarget::One(router.contract_address), owner);
+//     let first_swap = router
+//         .swap_exact_tokens_for_tokens(
+//             amountIn: amount_in,
+//             amountOutMin: 0,
+//             path: array![quote_address, memecoin_address],
+//             to: owner,
+//             deadline: starknet::get_block_timestamp()
+//         );
+//     let first_out = *first_swap[0];
 
-    // Max buy cap is `MAX_PERCENTAGE_BUY_LAUNCH` of total supply
-    // Initial rate is roughly 1 ETH for 21M meme,
-    // so if max buy is ~ 2% of 1 ETH = 0.02 ETH
-    let amount_in = MAX_PERCENTAGE_BUY_LAUNCH.into() * pow_256(10, 14);
-    start_prank(CheatTarget::One(router.contract_address), owner);
-    let first_swap = router
-        .swap_exact_tokens_for_tokens(
-            amountIn: amount_in,
-            amountOutMin: 0,
-            path: array![quote_address, memecoin_address],
-            to: owner,
-            deadline: starknet::get_block_timestamp()
-        );
-    let first_out = *first_swap[0];
+//     start_prank(CheatTarget::One(memecoin_address), owner);
+//     memecoin.approve(JEDI_ROUTER_ADDRESS(), first_out);
+//     stop_prank(CheatTarget::One(quote.contract_address));
 
-    start_prank(CheatTarget::One(memecoin_address), owner);
-    memecoin.approve(JEDI_ROUTER_ADDRESS(), first_out);
-    stop_prank(CheatTarget::One(quote.contract_address));
+//     let _second_swap = router
+//         .swap_exact_tokens_for_tokens(
+//             amountIn: first_out,
+//             amountOutMin: 0,
+//             path: array![memecoin_address, quote_address],
+//             to: owner,
+//             deadline: starknet::get_block_timestamp()
+//         );
 
-    let _second_swap = router
-        .swap_exact_tokens_for_tokens(
-            amountIn: first_out,
-            amountOutMin: 0,
-            path: array![memecoin_address, quote_address],
-            to: owner,
-            deadline: starknet::get_block_timestamp()
-        );
+//     // Check token lock
+//     let locker = ILockManagerDispatcher { contract_address: LOCK_MANAGER_ADDRESS() };
+//     let lock_address = locker.user_lock_at(owner, 0);
+//     let token_lock = locker.get_lock_details(lock_address);
+//     let expected_lock = LockPosition {
+//         token: pair_address,
+//         amount: pair.totalSupply() - 1000, // upon first mint, 1000 lp tokens are burnt
+//         unlock_time: starknet::get_block_timestamp() + DEFAULT_MIN_LOCKTIME,
+//         owner: owner,
+//     };
 
-    // Check token lock
-    let locker = ILockManagerDispatcher { contract_address: LOCK_MANAGER_ADDRESS() };
-    let lock_address = locker.user_lock_at(owner, 0);
-    let token_lock = locker.get_lock_details(lock_address);
-    let expected_lock = LockPosition {
-        token: pair_address,
-        amount: pair.totalSupply() - 1000, // upon first mint, 1000 lp tokens are burnt
-        unlock_time: starknet::get_block_timestamp() + DEFAULT_MIN_LOCKTIME,
-        owner: owner,
-    };
-
-    assert(token_lock == expected_lock, 'token lock details wrong');
-}
+//     assert(token_lock == expected_lock, 'token lock details wrong');
+// }
 
 #[test]
 #[fork("Mainnet")]

--- a/contracts/src/tests/fork_tests/utils.cairo
+++ b/contracts/src/tests/fork_tests/utils.cairo
@@ -110,6 +110,7 @@ fn deploy_memecoin_through_factory_with_owner(
     // occured in the same tx. Rather than adding these lines in each test, we make it a default.
     let mut tx_info: TxInfoMock = Default::default();
     tx_info.transaction_hash = Option::Some(1234);
+    tx_info.account_contract_address = Option::Some(snforge_std::test_address());
     start_spoof(CheatTarget::One(memecoin_address), tx_info);
 
     (IUnruggableMemecoinDispatcher { contract_address: memecoin_address }, memecoin_address)

--- a/contracts/src/tests/unit_tests.cairo
+++ b/contracts/src/tests/unit_tests.cairo
@@ -1,4 +1,5 @@
 mod test_factory;
+mod test_jediswap_integration;
 mod test_lock_manager;
 mod test_memecoin_erc20;
 mod test_unruggable_memecoin;

--- a/contracts/src/tests/unit_tests/test_factory.cairo
+++ b/contracts/src/tests/unit_tests/test_factory.cairo
@@ -45,8 +45,8 @@ fn test_locked_liquidity_jediswap() {
     let (locker_address, locked_type) = factory.locked_liquidity(memecoin_address).unwrap();
     assert(locker_address == LOCK_MANAGER_ADDRESS(), 'wrong locker address');
     match locked_type {
-        LiquidityType::ERC20(_) => (),
-        LiquidityType::NFT(_) => panic_with_felt252('wrong liquidity type')
+        LiquidityType::JediERC20(_) => (),
+        LiquidityType::EkuboNFT(_) => panic_with_felt252('wrong liquidity type')
     }
 }
 

--- a/contracts/src/tests/unit_tests/test_jediswap_integration.cairo
+++ b/contracts/src/tests/unit_tests/test_jediswap_integration.cairo
@@ -1,0 +1,110 @@
+use openzeppelin::token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
+use snforge_std::{
+    TxInfoMockTrait, start_spoof, stop_spoof, start_prank, stop_prank, start_warp, stop_warp,
+    CheatTarget
+};
+//TODO! Due to the bug in fork_tests/test_jediswap,
+// we deploy the contracts here instead of using the forked test.
+
+use unruggable::exchanges::jediswap_adapter::{
+    IJediswapFactoryDispatcher, IJediswapFactoryDispatcherTrait, IJediswapRouterDispatcher,
+    IJediswapRouterDispatcherTrait, IJediswapPairDispatcher, IJediswapPairDispatcherTrait,
+};
+use unruggable::factory::interface::{IFactoryDispatcher, IFactoryDispatcherTrait};
+use unruggable::locker::interface::{
+    ILockManagerDispatcher, ILockManagerDispatcherTrait, LockPosition
+};
+use unruggable::tests::addresses::{JEDI_ROUTER_ADDRESS};
+use unruggable::tests::unit_tests::utils::{
+    deploy_memecoin_through_factory_with_owner, TRANSFER_RESTRICTION_DELAY,
+    MAX_PERCENTAGE_BUY_LAUNCH, deploy_eth_with_owner, MEMEFACTORY_ADDRESS, LOCK_MANAGER_ADDRESS,
+    DEFAULT_MIN_LOCKTIME, pow_256, deploy_jedi_amm_factory_and_router, deploy_meme_factory,
+    deploy_eth, ETH_ADDRESS
+};
+use unruggable::token::interface::{
+    IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
+};
+
+#[test]
+fn test_jediswap_integration() {
+    let owner = snforge_std::test_address();
+    let (memecoin, memecoin_address) = deploy_memecoin_through_factory_with_owner(owner);
+    let factory = IFactoryDispatcher { contract_address: MEMEFACTORY_ADDRESS() };
+    let eth = ERC20ABIDispatcher { contract_address: ETH_ADDRESS() };
+    let router = IJediswapRouterDispatcher { contract_address: JEDI_ROUTER_ADDRESS() };
+
+    // approve spending of eth by factory
+    let eth_amount: u256 = 1 * pow_256(10, 18); // 1 ETHER
+    let factory_balance_meme = memecoin.balanceOf(factory.contract_address);
+    start_prank(CheatTarget::One(eth.contract_address), owner);
+    eth.approve(factory.contract_address, eth_amount);
+    stop_prank(CheatTarget::One(eth.contract_address));
+
+    start_prank(CheatTarget::One(factory.contract_address), owner);
+    // Set non-zero timestamp as the is_launched check is based on block timestamp
+    start_warp(CheatTarget::One(memecoin_address), 1);
+    let pair_address = factory
+        .launch_on_jediswap(
+            memecoin_address,
+            TRANSFER_RESTRICTION_DELAY,
+            MAX_PERCENTAGE_BUY_LAUNCH,
+            eth.contract_address,
+            eth_amount,
+            DEFAULT_MIN_LOCKTIME,
+        );
+    stop_prank(CheatTarget::One(factory.contract_address));
+    stop_warp(CheatTarget::One(memecoin_address));
+
+    // Approve required token amounts
+    start_prank(CheatTarget::One(eth.contract_address), owner);
+    eth.approve(JEDI_ROUTER_ADDRESS(), 1 * pow_256(10, 18));
+    stop_prank(CheatTarget::One(eth.contract_address));
+
+    // Max buy cap is `MAX_PERCENTAGE_BUY_LAUNCH` of total supply
+    // Initial rate is roughly 1 ETH for 21M meme,
+    // so if max buy is ~ 2% of 1 ETH = 0.02 ETH
+    let amount_in = MAX_PERCENTAGE_BUY_LAUNCH.into() * pow_256(10, 14);
+    start_prank(CheatTarget::One(router.contract_address), owner);
+    let first_swap = router
+        .swap_exact_tokens_for_tokens(
+            amountIn: amount_in,
+            amountOutMin: 0,
+            path: array![eth.contract_address, memecoin_address],
+            to: owner,
+            deadline: starknet::get_block_timestamp()
+        );
+    stop_prank(CheatTarget::One(router.contract_address));
+
+    let first_out = *first_swap[0];
+
+    start_prank(CheatTarget::One(memecoin_address), owner);
+    memecoin.approve(router.contract_address, first_out);
+    stop_prank(CheatTarget::One(memecoin_address));
+
+    let balanceofOwnermemecoin = memecoin.balanceOf(owner);
+
+    start_prank(CheatTarget::One(router.contract_address), owner);
+    let _second_swap = router
+        .swap_exact_tokens_for_tokens(
+            amountIn: first_out,
+            amountOutMin: 0,
+            path: array![memecoin_address, eth.contract_address],
+            to: owner,
+            deadline: starknet::get_block_timestamp() + 10000
+        );
+    stop_prank(CheatTarget::One(router.contract_address));
+
+    // Check token lock
+    let pair = IJediswapPairDispatcher { contract_address: pair_address };
+    let locker = ILockManagerDispatcher { contract_address: LOCK_MANAGER_ADDRESS() };
+    let lock_address = locker.user_lock_at(owner, 0);
+    let token_lock = locker.get_lock_details(lock_address);
+    let expected_lock = LockPosition {
+        token: pair_address,
+        amount: pair.totalSupply() - 1000, // upon first mint, 1000 lp tokens are burnt
+        unlock_time: starknet::get_block_timestamp() + DEFAULT_MIN_LOCKTIME,
+        owner: owner,
+    };
+
+    assert(token_lock == expected_lock, 'token lock details wrong');
+}

--- a/frontend/src/constants/misc.ts
+++ b/frontend/src/constants/misc.ts
@@ -29,8 +29,8 @@ export enum AMM {
 }
 
 export enum LiquidityType {
-  ERC20 = 'ERC20',
-  NFT = 'NFT',
+  ERC20 = 'JediERC20',
+  NFT = 'EkuboNFT',
 }
 
 export const MIN_STARTING_MCAP = 5_000 // $5k


### PR DESCRIPTION
As reported by 
- @ermvrs [L-02],
- @0xEniotna [L-04], 
- @credence0x [C-02]

The `ensure_not_multicall` would handicap aggregators as it would disable the possibility to transfer the token twice in the same transaction.

Mitigation:
Only add transfer checks when the transfer is in the context of a **BUY** transaction, namely
- When the caller is the jediswap pair itself OR when the caller is Ekubo Core itself.

This solution enables us to:
- Keep multicall prevention to disable multibuys in the same TX
- Make the coin compatible with aggregators (unless they buy on two different exchanges - but we assume that the liquidity will only be concentrated in a single pool, at least during the restriction phase)

As a counterparty, it
- Disables the transfer checks for other types of transactions. I don't think it's very important.