### PR TITLE
refactor: distribute initial tokens only after launch and buy them from ekubo pool (if applicable)

### DIFF
--- a/contracts/src/exchanges.cairo
+++ b/contracts/src/exchanges.cairo
@@ -15,6 +15,7 @@ trait ExchangeAdapter<A, R> {
         exchange_address: ContractAddress,
         token_address: ContractAddress,
         quote_address: ContractAddress,
+        lp_supply: u256,
         additional_parameters: A,
     ) -> R;
 }

--- a/contracts/src/exchanges/ekubo.cairo
+++ b/contracts/src/exchanges/ekubo.cairo
@@ -1,5 +1,5 @@
 mod ekubo_adapter;
 mod errors;
+mod helpers;
 mod interfaces;
 mod launcher;
-mod helpers;

--- a/contracts/src/exchanges/ekubo.cairo
+++ b/contracts/src/exchanges/ekubo.cairo
@@ -2,3 +2,4 @@ mod ekubo_adapter;
 mod errors;
 mod interfaces;
 mod launcher;
+mod helpers;

--- a/contracts/src/exchanges/ekubo/ekubo_adapter.cairo
+++ b/contracts/src/exchanges/ekubo/ekubo_adapter.cairo
@@ -2,7 +2,13 @@ use array::ArrayTrait;
 use core::option::OptionTrait;
 use core::traits::TryInto;
 use debug::PrintTrait;
+use ekubo::components::clear::{IClearDispatcher, IClearDispatcherTrait};
+use ekubo::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+use ekubo::interfaces::router::{Depth, Delta, RouteNode, TokenAmount};
+use ekubo::interfaces::router::{IRouterDispatcher, IRouterDispatcherTrait};
+use ekubo::types::bounds::Bounds;
 use ekubo::types::i129::i129;
+use ekubo::types::keys::PoolKey;
 use openzeppelin::token::erc20::interface::{
     IERC20, IERC20Metadata, ERC20ABIDispatcher, ERC20ABIDispatcherTrait
 };
@@ -15,6 +21,7 @@ use unruggable::token::interface::{
     IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait,
 };
 use unruggable::utils::math::PercentageMath;
+use unruggable::utils::sort_tokens;
 
 
 #[derive(Copy, Drop, Serde)]
@@ -22,6 +29,7 @@ struct EkuboLaunchParameters {
     owner: ContractAddress,
     token_address: ContractAddress,
     quote_address: ContractAddress,
+    lp_supply: u256,
     pool_params: EkuboPoolParameters
 }
 
@@ -42,12 +50,14 @@ impl EkuboAdapterImpl of unruggable::exchanges::ExchangeAdapter<
         exchange_address: ContractAddress,
         token_address: ContractAddress,
         quote_address: ContractAddress,
+        lp_supply: u256,
         additional_parameters: EkuboPoolParameters,
     ) -> (u64, EkuboLP) {
         let ekubo_launch_params = EkuboLaunchParameters {
             owner: starknet::get_caller_address(),
             token_address: token_address,
             quote_address: quote_address,
+            lp_supply: lp_supply,
             pool_params: EkuboPoolParameters {
                 fee: additional_parameters.fee,
                 tick_spacing: additional_parameters.tick_spacing,
@@ -55,28 +65,113 @@ impl EkuboAdapterImpl of unruggable::exchanges::ExchangeAdapter<
                 bound: additional_parameters.bound,
             }
         };
-
-        let this = get_contract_address();
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address: token_address, };
-        let memecoin_address = memecoin.contract_address;
-        let quote_token = ERC20ABIDispatcher { contract_address: quote_address, };
-
         let ekubo_launchpad = IEkuboLauncherDispatcher { contract_address: exchange_address };
         assert(ekubo_launchpad.contract_address.is_non_zero(), errors::EXCHANGE_ADDRESS_ZERO);
 
-        // Transfer the tokens to the launchpad contract.
-        let memecoin_balance = memecoin.balance_of(this);
-        memecoin.transfer(ekubo_launchpad.contract_address, memecoin_balance);
+        // Transfer all tokens to the launchpad contract.
+        // The team will buyback the tokens from the pool after the LPing operation to earn their initial allocation.
+        let memecoin = IUnruggableMemecoinDispatcher { contract_address: token_address, };
+        let memecoin_address = memecoin.contract_address;
+        let this = get_contract_address();
+        memecoin.transfer(ekubo_launchpad.contract_address, memecoin.balance_of(this));
 
         let (id, position) = ekubo_launchpad.launch_token(ekubo_launch_params);
 
         // Ensure that the LPing operation has not returned more than 0.5% of the provided liquidity to the caller.
         // Otherwise, there was an error in the LP parameters.
         let total_supply = memecoin.total_supply();
-        let team_alloc = memecoin.get_team_allocation();
-        let max_returned_tokens = PercentageMath::percent_mul(total_supply - team_alloc, 9950);
+        let max_returned_tokens = PercentageMath::percent_mul(total_supply, 9950);
         assert(memecoin.balanceOf(this) < max_returned_tokens, 'ekubo has returned tokens');
+
+        // Finally, buy the reserved team tokens from the pool.
+        // As the pool was created with a fixed price for these n% allocated to the team, there should be no slippage.
+        let (token0, token1) = sort_tokens(token_address, ekubo_launch_params.quote_address);
+        let pool_key = PoolKey {
+            token0: token0,
+            token1: token1,
+            fee: ekubo_launch_params.pool_params.fee,
+            tick_spacing: ekubo_launch_params.pool_params.tick_spacing,
+            extension: 0.try_into().unwrap(),
+        };
+        let team_alloc = total_supply - lp_supply;
+        buy_tokens_from_pool(
+            ekubo_launchpad, pool_key, team_alloc, memecoin_address, quote_address
+        );
+
+        println!("received {} tokens", memecoin.balanceOf(this));
+        assert(memecoin.balanceOf(this) >= team_alloc, 'failed buying team tokens');
+        // Allocation to the holders is done in the next step.
 
         (id, position)
     }
+}
+
+/// Buys tokens from a liquidity pool.
+///
+/// It first determines the square root price limits for the swap based on whether the quote token is token1 or token0 in the pool.
+/// It then creates a route node for the swap, transfers the quote tokens to the router contract,
+/// and calls the router's swap function with an exact output amount.
+/// Finally, it calls the clearer's clear function for both the token to buy and the quote token.
+///
+/// # Arguments
+///
+/// * `ekubo_launchpad` - A dispatcher for the Ekubo launchpad contract.
+/// * `pool_key` - The key of the liquidity pool.
+/// * `amount` - The amount of tokens to buy.
+/// * `token_to_buy` - The address of the token to buy.
+/// * `quote_address` - The address of the quote token.
+///
+fn buy_tokens_from_pool(
+    ekubo_launchpad: IEkuboLauncherDispatcher,
+    pool_key: PoolKey,
+    amount: u256,
+    token_to_buy: ContractAddress,
+    quote_address: ContractAddress,
+) {
+    let ekubo_router = IRouterDispatcher {
+        contract_address: ekubo_launchpad.ekubo_router_address()
+    };
+    let ekubo_clearer = IClearDispatcher {
+        contract_address: ekubo_launchpad.ekubo_router_address()
+    };
+
+    let token_to_buy = IUnruggableMemecoinDispatcher { contract_address: token_to_buy };
+
+    let max_sqrt_ratio_limit = 6277100250585753475930931601400621808602321654880405518632;
+    let min_sqrt_ratio_limit = 18446748437148339061;
+
+    let is_token1 = pool_key.token1 == quote_address;
+    let (sqrt_limit_swap1, sqrt_limit_swap2) = if is_token1 {
+        (max_sqrt_ratio_limit, min_sqrt_ratio_limit)
+    } else {
+        (min_sqrt_ratio_limit, max_sqrt_ratio_limit)
+    };
+
+    let route_node = RouteNode {
+        pool_key: pool_key, sqrt_ratio_limit: sqrt_limit_swap1, skip_ahead: 0
+    };
+
+    let quote_token = IERC20Dispatcher { contract_address: quote_address };
+    let this = get_contract_address();
+    println!("factory buying {} tokens", amount.low);
+    println!("factory quote balance is {}", quote_token.balanceOf(this));
+    // Buy tokens from the pool, with an exact output amount.
+    let token_amount = TokenAmount {
+        token: token_to_buy.contract_address,
+        amount: i129 { mag: amount.low, sign: true // negative (true) sign is exact output
+         },
+    };
+
+    // We transfer quote tokens to the swapper contract, which performs the swap
+    // It then sends back the funds to the caller once cleared.
+    quote_token.transfer(ekubo_router.contract_address, quote_token.balanceOf(this));
+    println!("transfer successful");
+    // Swap and clear the tokens to finalize.
+    ekubo_router.swap(route_node, token_amount);
+    println!("Swap successful");
+    ekubo_clearer.clear(IERC20Dispatcher { contract_address: token_to_buy.contract_address });
+    ekubo_clearer
+        .clear_minimum_to_recipient(
+            IERC20Dispatcher { contract_address: quote_address }, 0, starknet::get_caller_address()
+        );
 }

--- a/contracts/src/exchanges/ekubo/ekubo_adapter.cairo
+++ b/contracts/src/exchanges/ekubo/ekubo_adapter.cairo
@@ -76,7 +76,6 @@ impl EkuboAdapterImpl of unruggable::exchanges::ExchangeAdapter<
 
         // Launch the token, which creates two positions: one concentrated at initial_tick
         // for the team allocation and one on the range [initial_tick, inf] for the initial LP.
-        println!("Launching token on Ekubo");
         let (id, position) = ekubo_launchpad.launch_token(ekubo_launch_params);
 
         // Ensure that the LPing operation has not returned more than 0.5% of the provided liquidity to the caller.
@@ -165,11 +164,9 @@ fn buy_tokens_from_pool(
 
     // We transfer quote tokens to the swapper contract, which performs the swap
     // It then sends back the funds to the caller once cleared.
-    println!("Transferring quote tokens to the router contract");
     quote_token.transfer(ekubo_router.contract_address, quote_token.balanceOf(this));
     // Swap and clear the tokens to finalize.
     ekubo_router.swap(route_node, token_amount);
-    println!("Clearing tokens");
     ekubo_clearer.clear(IERC20Dispatcher { contract_address: token_to_buy.contract_address });
     ekubo_clearer
         .clear_minimum_to_recipient(

--- a/contracts/src/exchanges/ekubo/ekubo_adapter.cairo
+++ b/contracts/src/exchanges/ekubo/ekubo_adapter.cairo
@@ -38,7 +38,7 @@ struct EkuboPoolParameters {
     fee: u128,
     tick_spacing: u128,
     // the sign of the starting tick is positive (false) if quote/token < 1 and negative (true) otherwise
-    starting_tick: i129,
+    starting_price: i129,
     // The LP providing bound, upper/lower determined by the address of the LPed tokens
     bound: u128,
 }
@@ -61,7 +61,7 @@ impl EkuboAdapterImpl of unruggable::exchanges::ExchangeAdapter<
             pool_params: EkuboPoolParameters {
                 fee: additional_parameters.fee,
                 tick_spacing: additional_parameters.tick_spacing,
-                starting_tick: additional_parameters.starting_tick,
+                starting_price: additional_parameters.starting_price,
                 bound: additional_parameters.bound,
             }
         };
@@ -93,13 +93,13 @@ impl EkuboAdapterImpl of unruggable::exchanges::ExchangeAdapter<
             tick_spacing: ekubo_launch_params.pool_params.tick_spacing,
             extension: 0.try_into().unwrap(),
         };
-        let team_alloc = total_supply - lp_supply;
+        let team_allocation = total_supply - lp_supply;
         buy_tokens_from_pool(
-            ekubo_launchpad, pool_key, team_alloc, memecoin_address, quote_address
+            ekubo_launchpad, pool_key, team_allocation, memecoin_address, quote_address
         );
 
         println!("received {} tokens", memecoin.balanceOf(this));
-        assert(memecoin.balanceOf(this) >= team_alloc, 'failed buying team tokens');
+        assert(memecoin.balanceOf(this) >= team_allocation, 'failed buying team tokens');
         // Allocation to the holders is done in the next step.
 
         (id, position)

--- a/contracts/src/exchanges/ekubo/helpers.cairo
+++ b/contracts/src/exchanges/ekubo/helpers.cairo
@@ -1,0 +1,108 @@
+use ekubo::types::i129::i129;
+use ekubo::types::bounds::Bounds;
+
+/// Calculates the initial tick and bounds for a liquidity pool from the starting price and the magnitude of the single bound delimiting the range [starting_price, upper_bound] or [lower_bound, starting_price].
+///
+/// # Arguments
+///
+/// * `starting_price` - The initial price of the token pair.
+/// * `bound_mag` - The magintude of bound.
+/// * `is_token1_quote` - A boolean indicating whether token1 is the quote currency.
+///
+/// # Returns
+///
+/// * A tuple containing the initial tick and the bounds.
+///
+/// If `is_token1_quote` is true, the initial tick and lower bound are set to the starting price,
+/// and the upper bound is set to the provided bound as a positive integer.
+///
+/// If `is_token1_quote` is false, the initial tick and upper bound are set to the negative of the starting price,
+/// and the lower bound is set to the provided bound as a negative integer.
+///
+/// The sign of the initial tick is reversed if the quote is token0, as the price provided was expressed in token1/token0.
+///
+fn get_initial_tick_from_starting_price(
+    starting_price: i129, bound_mag: u128, is_token1_quote: bool
+) -> (i129, Bounds) {
+    let (initial_tick, bounds) = if is_token1_quote {
+        (
+            i129 { sign: starting_price.sign, mag: starting_price.mag },
+            Bounds {
+                lower: i129 { sign: starting_price.sign, mag: starting_price.mag },
+                upper: i129 { sign: false, mag: bound_mag }
+            }
+        )
+    } else {
+        // The initial tick sign is reversed if the quote is token0.
+        // as the price provided was expressed in token1/token0.
+        (
+            i129 { sign: !starting_price.sign, mag: starting_price.mag },
+            Bounds {
+                lower: i129 { sign: true, mag: bound_mag },
+                upper: i129 { sign: !starting_price.sign, mag: starting_price.mag }
+            }
+        )
+    };
+    (initial_tick, bounds)
+}
+
+
+/// Calculates the next tick bounds based on the starting tick, tick spacing, and whether token1 is the quote token.
+///
+/// The starting tick is always expressed in terms of MEME/QUOTE. The conversion is done internally to the contract.
+/// The bounds are calculated differently depending on whether token1 is the quote token and whether the starting tick is positive or negative.
+///
+/// If token1 is the quote token and the starting tick is negative, buying makes the price go up,
+/// so the upper bound is the starting tick - tick spacing and the lower bound is the starting tick.
+///
+/// If token1 is the quote token and the starting tick is positive, buying makes the price go down.
+/// so the lower bound is the starting tick - tick spacing and the upper bound is the starting tick.
+///
+/// If token1 is not the quote token and the starting tick is negative, buying makes the price go down.
+/// so the lower bound is the starting tick and the upper bound is the starting tick + tick spacing.
+
+/// If token1 is not the quote token and the starting tick is negative, buying makes the price go up.
+/// so the upper bound is the starting tick + tick spacing and the lower bound is the starting tick.
+///
+/// # Arguments
+///
+/// * `starting_price` - The starting tick.
+/// * `tick_spacing` - The spacing between ticks.
+/// * `is_token1_quote` - Whether token1 is the quote token.
+///
+/// # Returns
+///
+/// * `Bounds` - The lower and upper bounds for the next tick.
+///
+fn get_next_tick_bounds(starting_price: i129, tick_spacing: u128, is_token1_quote: bool) -> Bounds {
+    if is_token1_quote {
+        if starting_price.sign {
+            // Case 1 -> price meme/quote > 0, pool price < 0, buying makes price go up
+            Bounds {
+                lower: i129 { sign: true, mag: starting_price.mag },
+                upper: i129 { sign: true, mag: starting_price.mag - tick_spacing }
+            }
+        // Case 2 -> price meme/quote < 0, pool price > 0, buying makes price go down
+        } else {
+            // Case 2 -> price meme/quote < 0, pool price > 0, buying makes price go down
+            Bounds {
+                lower: i129 { sign: false, mag: starting_price.mag - tick_spacing },
+                upper: i129 { sign: false, mag: starting_price.mag }
+            }
+        }
+    } else {
+        if starting_price.sign {
+            // Case 3 -> price meme/quote < 0, pool price < 0, buying makes price go down
+            Bounds {
+                lower: i129 { sign: true, mag: starting_price.mag + tick_spacing },
+                upper: i129 { sign: true, mag: starting_price.mag }
+            }
+        } else {
+            // Case 4 -> price meme/quote > 0, pool price > 0, buying makes price go up
+            Bounds {
+                lower: i129 { sign: false, mag: starting_price.mag },
+                upper: i129 { sign: false, mag: starting_price.mag + tick_spacing }
+            }
+        }
+    }
+}

--- a/contracts/src/exchanges/ekubo/helpers.cairo
+++ b/contracts/src/exchanges/ekubo/helpers.cairo
@@ -1,5 +1,5 @@
-use ekubo::types::i129::i129;
 use ekubo::types::bounds::Bounds;
+use ekubo::types::i129::i129;
 
 /// Calculates the initial tick and bounds for a liquidity pool from the starting price and the magnitude of the single bound delimiting the range [starting_price, upper_bound] or [lower_bound, starting_price].
 ///

--- a/contracts/src/exchanges/ekubo/launcher.cairo
+++ b/contracts/src/exchanges/ekubo/launcher.cairo
@@ -438,11 +438,10 @@ mod EkuboLauncher {
                         extension: 0.try_into().unwrap(),
                     };
 
-                    let is_token1_quote = launch_params.quote_address == token1;
-
                     // The initial_tick must correspond to the wanted initial price in quote/MEME
                     // The ekubo prices are always in TOKEN1/TOKEN0.
                     // The initial_tick is the lower bound if the quote is token1, the upper bound otherwise.
+                    let is_token1_quote = launch_params.quote_address == token1;
                     let (initial_tick, full_range_bounds) = get_initial_tick_from_starting_price(
                         launch_params.pool_params.starting_price,
                         launch_params.pool_params.bound,
@@ -463,7 +462,6 @@ mod EkuboLauncher {
                     let this = get_contract_address();
                     let liquidity_for_team = launched_token.balanceOf(this)
                         - launch_params.lp_supply;
-                    println!("liquidity_for_team: {}", liquidity_for_team);
                     let single_tick_bound = get_next_tick_bounds(
                         launch_params.pool_params.starting_price,
                         launch_params.pool_params.tick_spacing,
@@ -476,11 +474,12 @@ mod EkuboLauncher {
                             liquidity_for_team,
                             single_tick_bound
                         );
-                    println!("First LP done");
+
+                    let ekubo_router = self.router.read();
+                    // let market_depth = ekubo_router
+                    //     .get_market_depth(pool_key, 985392111309755760868507187842908160);
 
                     // 2. Provide the liquidity to actually initialize the public pool with
-                    // Transfer the balance of the launched token to be used in the LP.
-
                     // The pool bounds must be set according to the tick spacing.
                     // The bounds were previously computed to provide yield covering the entire interval
                     // [lower_bound, starting_price]  or [starting_price, upper_bound] depending on the quote.
@@ -491,7 +490,6 @@ mod EkuboLauncher {
                             launch_params.lp_supply,
                             full_range_bounds
                         );
-                    println!("Second LP done");
 
                     // At this point, the pool is composed by:
                     // n% of liquidity at precise starting tick, reserved for the team to buy

--- a/contracts/src/factory.cairo
+++ b/contracts/src/factory.cairo
@@ -10,4 +10,6 @@ struct LaunchParameters {
     transfer_restriction_delay: u64,
     max_percentage_buy_launch: u16,
     quote_address: starknet::ContractAddress,
+    initial_holders: Span<starknet::ContractAddress>,
+    initial_holders_amounts: Span<u256>,
 }

--- a/contracts/src/factory.cairo
+++ b/contracts/src/factory.cairo
@@ -3,3 +3,11 @@ mod interface;
 use factory::Factory;
 
 use interface::{IFactory, IFactoryDispatcher, IFactoryDispatcherTrait};
+
+#[derive(Copy, Drop, Serde)]
+struct LaunchParameters {
+    memecoin_address: starknet::ContractAddress,
+    transfer_restriction_delay: u64,
+    max_percentage_buy_launch: u16,
+    quote_address: starknet::ContractAddress,
+}

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -126,7 +126,7 @@ mod Factory {
             quote_amount: u256,
             unlock_time: u64,
         ) -> ContractAddress {
-            let (team_alloc, pre_holders) = check_common_launch_parameters(
+            let (team_allocation, pre_holders) = check_common_launch_parameters(
                 @self, launch_parameters
             );
             let router_address = self.exchange_address(SupportedExchanges::Jediswap);
@@ -145,7 +145,7 @@ mod Factory {
                 exchange_address: router_address,
                 token_address: memecoin_address,
                 quote_address: quote_address,
-                lp_supply: memecoin.total_supply() - team_alloc,
+                lp_supply: memecoin.total_supply() - team_allocation,
                 additional_parameters: JediswapAdditionalParameters {
                     lock_manager_address: self.lock_manager_address.read(),
                     unlock_time,
@@ -164,7 +164,8 @@ mod Factory {
                 .set_launched(
                     LiquidityType::JediERC20(pair_address),
                     :transfer_restriction_delay,
-                    :max_percentage_buy_launch
+                    :max_percentage_buy_launch,
+                    :team_allocation
                 );
             self
                 .emit(
@@ -180,7 +181,7 @@ mod Factory {
             launch_parameters: LaunchParameters,
             ekubo_parameters: EkuboPoolParameters,
         ) -> (u64, EkuboLP) {
-            let (team_alloc, pre_holders) = check_common_launch_parameters(
+            let (team_allocation, pre_holders) = check_common_launch_parameters(
                 @self, launch_parameters
             );
 
@@ -194,14 +195,14 @@ mod Factory {
 
             let launchpad_address = self.exchange_address(SupportedExchanges::Ekubo);
             assert(launchpad_address.is_non_zero(), errors::EXCHANGE_ADDRESS_ZERO);
-            assert(ekubo_parameters.starting_tick.mag.is_non_zero(), errors::PRICE_ZERO);
+            assert(ekubo_parameters.starting_price.mag.is_non_zero(), errors::PRICE_ZERO);
 
             let memecoin = IUnruggableMemecoinDispatcher { contract_address: memecoin_address };
             let (id, position) = ekubo_adapter::EkuboAdapterImpl::create_and_add_liquidity(
                 exchange_address: launchpad_address,
                 token_address: memecoin_address,
                 quote_address: quote_address,
-                lp_supply: memecoin.total_supply() - team_alloc,
+                lp_supply: memecoin.total_supply() - team_allocation,
                 additional_parameters: ekubo_parameters
             );
 
@@ -211,7 +212,8 @@ mod Factory {
                 .set_launched(
                     LiquidityType::EkuboNFT(id),
                     :transfer_restriction_delay,
-                    :max_percentage_buy_launch
+                    :max_percentage_buy_launch,
+                    :team_allocation
                 );
             self
                 .emit(

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -153,9 +153,6 @@ mod Factory {
                 }
             );
 
-            //TODO Write the team alloc in storage of the memecoin.
-            // self.team_allocation.write(team_allocation);
-            // self.pre_launch_holders_count.write(unique_count(initial_holders).try_into().unwrap());
 
             // Transfer the team's alloc
             distribute_team_alloc(memecoin, initial_holders, initial_holders_amounts);
@@ -206,7 +203,6 @@ mod Factory {
                 additional_parameters: ekubo_parameters
             );
 
-            // TODO: write team alloc and unique holders in memecoin
             distribute_team_alloc(memecoin, initial_holders, initial_holders_amounts);
             memecoin
                 .set_launched(

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -153,7 +153,6 @@ mod Factory {
                 }
             );
 
-
             // Transfer the team's alloc
             distribute_team_alloc(memecoin, initial_holders, initial_holders_amounts);
 

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -29,6 +29,17 @@ mod Factory {
     use unruggable::token::interface::{
         IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
     };
+    use unruggable::utils::math::PercentageMath;
+    use unruggable::utils::unique_count;
+
+    /// The maximum percentage of the total supply that can be allocated to the team.
+    /// This is to prevent the team from having too much control over the supply.
+    const MAX_SUPPLY_PERCENTAGE_TEAM_ALLOCATION: u16 = 1_000; // 10%
+
+    /// The maximum number of holders one can specify when launching.
+    /// This is to prevent the contract from being is_launched with a large number of holders.
+    /// Once reached, transfers are disabled until the memecoin is is_launched.
+    const MAX_HOLDERS_LAUNCH: u8 = 10;
 
     #[event]
     #[derive(Drop, starknet::Event)]
@@ -91,14 +102,10 @@ mod Factory {
             name: felt252,
             symbol: felt252,
             initial_supply: u256,
-            initial_holders: Span<ContractAddress>,
-            initial_holders_amounts: Span<u256>,
             contract_address_salt: felt252,
         ) -> ContractAddress {
             let mut calldata = array![owner.into(), name.into(), symbol.into()];
             Serde::serialize(@initial_supply, ref calldata);
-            Serde::serialize(@initial_holders.into(), ref calldata);
-            Serde::serialize(@initial_holders_amounts.into(), ref calldata);
 
             let (memecoin_address, _) = deploy_syscall(
                 self.memecoin_class_hash.read(), contract_address_salt, calldata.span(), false
@@ -119,14 +126,18 @@ mod Factory {
             quote_amount: u256,
             unlock_time: u64,
         ) -> ContractAddress {
-            assert_common_launch_parameters(@self, launch_parameters);
+            let (team_alloc, pre_holders) = check_common_launch_parameters(
+                @self, launch_parameters
+            );
             let router_address = self.exchange_address(SupportedExchanges::Jediswap);
             assert(router_address.is_non_zero(), errors::EXCHANGE_ADDRESS_ZERO);
 
             let LaunchParameters{memecoin_address,
             transfer_restriction_delay,
             max_percentage_buy_launch,
-            quote_address } =
+            quote_address,
+            initial_holders,
+            initial_holders_amounts } =
                 launch_parameters;
 
             let memecoin = IUnruggableMemecoinDispatcher { contract_address: memecoin_address };
@@ -140,6 +151,10 @@ mod Factory {
                     quote_amount
                 }
             );
+
+            // Write the team alloc in storage of the memecoin.
+            // self.team_allocation.write(team_allocation);
+            // self.pre_launch_holders_count.write(unique_count(initial_holders).try_into().unwrap());
 
             memecoin
                 .set_launched(
@@ -161,12 +176,16 @@ mod Factory {
             launch_parameters: LaunchParameters,
             ekubo_parameters: EkuboPoolParameters,
         ) -> (u64, EkuboLP) {
-            assert_common_launch_parameters(@self, launch_parameters);
+            let (team_alloc, pre_holders) = check_common_launch_parameters(
+                @self, launch_parameters
+            );
 
             let LaunchParameters{memecoin_address,
             transfer_restriction_delay,
             max_percentage_buy_launch,
-            quote_address } =
+            quote_address,
+            initial_holders,
+            initial_holders_amounts } =
                 launch_parameters;
 
             let memecoin = IUnruggableMemecoinDispatcher { contract_address: memecoin_address };
@@ -182,6 +201,7 @@ mod Factory {
                 additional_parameters: ekubo_parameters
             );
 
+            // TODO: write team alloc and unique holders in memecoin
             memecoin
                 .set_launched(
                     LiquidityType::EkuboNFT(id),
@@ -236,17 +256,76 @@ mod Factory {
         }
     }
 
-    fn assert_common_launch_parameters(self: @ContractState, launch_parameters: LaunchParameters) {
+
+    /// Checks the launch parameters and calculates the team allocation.
+    ///
+    /// This function checks that the memecoin and quote addresses are valid,
+    /// that the caller is the owner of the memecoin,
+    /// that the memecoin has not been launched,
+    /// and that the lengths of the initial holders and their amounts are equal and do not exceed the maximum allowed.
+    /// It then calculates the maximum team allocation as a percentage of the total supply,
+    /// and iteratively adds the amounts of the initial holders to the team allocation,
+    /// ensuring that the total allocation does not exceed the maximum.
+    /// It finally returns the total team allocation and the count of unique initial holders.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - A reference to the ContractState struct.
+    /// * `launch_parameters` - The parameters for the token launch.
+    ///
+    /// # Returns
+    ///
+    /// * `(u256, u8)` - The total amount of memecoin allocated to the team and the count of unique initial holders.
+    ///
+    /// # Panics
+    ///
+    /// * If the memecoin address is not a memecoin.
+    /// * If the quote address is a memecoin.
+    /// * If the caller is not the owner of the memecoin.
+    /// * If the memecoin has been launched.
+    /// * If the lengths of the initial holders and their amounts are not equal.
+    /// * If the number of initial holders exceeds the maximum allowed.
+    /// * If the total team allocation exceeds the maximum allowed.
+    ///
+    fn check_common_launch_parameters(
+        self: @ContractState, launch_parameters: LaunchParameters
+    ) -> (u256, u8) {
         let LaunchParameters{memecoin_address,
         transfer_restriction_delay,
         max_percentage_buy_launch,
-        quote_address } =
+        quote_address,
+        initial_holders,
+        initial_holders_amounts } =
             launch_parameters;
         let memecoin = IUnruggableMemecoinDispatcher { contract_address: memecoin_address };
 
         assert(self.is_memecoin(memecoin_address), errors::NOT_UNRUGGABLE);
         assert(!self.is_memecoin(quote_address), errors::QUOTE_TOKEN_IS_MEMECOIN);
-        assert(get_caller_address() == memecoin.owner(), errors::CALLER_NOT_OWNER);
         assert(!memecoin.is_launched(), errors::ALREADY_LAUNCHED);
+        assert(get_caller_address() == memecoin.owner(), errors::CALLER_NOT_OWNER);
+        assert(initial_holders.len() == initial_holders_amounts.len(), errors::ARRAYS_LEN_DIF);
+        assert(initial_holders.len() <= MAX_HOLDERS_LAUNCH.into(), errors::MAX_HOLDERS_REACHED);
+
+        let initial_supply = memecoin.total_supply();
+
+        // Check that the sum of the amounts of initial holders does not exceed the max allocatable supply for a team.
+        let max_team_allocation = initial_supply
+            .percent_mul(MAX_SUPPLY_PERCENTAGE_TEAM_ALLOCATION.into());
+        let mut team_allocation: u256 = 0;
+        let mut i: usize = 0;
+        loop {
+            if i == initial_holders.len() {
+                break;
+            }
+
+            let address = *initial_holders.at(i);
+            let amount = *initial_holders_amounts.at(i);
+
+            team_allocation += amount;
+            assert(team_allocation <= max_team_allocation, errors::MAX_TEAM_ALLOCATION_REACHED);
+            i += 1;
+        };
+
+        (team_allocation, unique_count(initial_holders).try_into().unwrap())
     }
 }

--- a/contracts/src/factory/interface.cairo
+++ b/contracts/src/factory/interface.cairo
@@ -83,7 +83,7 @@ trait IFactory<TContractState> {
     /// * `ekubo_parameters` - The parameters for the ekubo liquidity pool, including:
     ///     - `fee` - The fee for the liquidity pair.
     ///     - `tick_spacing` - The spacing between ticks for the liquidity pool.
-    ///     - `starting_tick` - The starting tick for the liquidity pool.
+    ///     - `starting_price` - The starting tick for the liquidity pool.
     ///     - `bound` - The bound for the liquidity pool - should be set to the max tick for this pool (the sign is determined in the contract).
     ///
     /// # Returns

--- a/contracts/src/factory/interface.cairo
+++ b/contracts/src/factory/interface.cairo
@@ -4,6 +4,7 @@ use starknet::ContractAddress;
 use unruggable::exchanges::SupportedExchanges;
 use unruggable::exchanges::ekubo::launcher::EkuboLP;
 use unruggable::exchanges::ekubo_adapter::EkuboPoolParameters;
+use unruggable::factory::LaunchParameters;
 use unruggable::token::memecoin::LiquidityType;
 
 #[starknet::interface]
@@ -43,11 +44,11 @@ trait IFactory<TContractState> {
     /// It creates a liquidity pair for the memecoin and the quote token on Jediswap, adds liquidity to it, and sets the memecoin as launched.
     ///
     /// # Arguments
-    ///
-    /// * `memecoin_address` - The address of the memecoin contract.
-    /// * `transfer_restriction_delay` - The delay in seconds during which transfers will be limited to a % of max supply after launch.
-    /// * `max_percentage_buy_launch` - The max buyable amount in % of the max supply after launch and during the transfer restriction delay.
-    /// * `quote_address` - The address of the quote token contract.
+    /// * launch_parameters - The parameters for the launch, including:
+    ///     * `memecoin_address` - The address of the memecoin contract.
+    ///     * `transfer_restriction_delay` - The delay in seconds during which transfers will be limited to a % of max supply after launch.
+    ///     * `max_percentage_buy_launch` - The max buyable amount in % of the max supply after launch and during the transfer restriction delay.
+    ///     * `quote_address` - The address of the quote token contract.
     /// * `quote_amount` - The amount of quote tokens to add as liquidity.
     /// * `unlock_time` - The timestamp when the liquidity can be unlocked.
     ///
@@ -64,10 +65,7 @@ trait IFactory<TContractState> {
     ///
     fn launch_on_jediswap(
         ref self: TContractState,
-        memecoin_address: ContractAddress,
-        transfer_restriction_delay: u64,
-        max_percentage_buy_launch: u16,
-        quote_address: ContractAddress,
+        launch_parameters: LaunchParameters,
         quote_amount: u256,
         unlock_time: u64,
     ) -> ContractAddress;
@@ -79,9 +77,11 @@ trait IFactory<TContractState> {
     ///
     /// # Arguments
     ///
-    /// * `memecoin_address` - The address of the memecoin contract.
-    /// * `transfer_restriction_delay` - The delay in seconds during which transfers will be limited to a % of max supply after launch.
-    /// * `quote_address` - The address of the quote token contract.
+    /// * launch_parameters - The parameters for the launch, including:
+    ///     * `memecoin_address` - The address of the memecoin contract.
+    ///     * `transfer_restriction_delay` - The delay in seconds during which transfers will be limited to a % of max supply after launch.
+    ///     * `max_percentage_buy_launch` - The max buyable amount in % of the max supply after launch and during the transfer restriction delay.
+    ///     * `quote_address` - The address of the quote token contract.
     /// * `ekubo_parameters` - The parameters for the ekubo liquidity pool, including:
     ///     - `fee` - The fee for the liquidity pair.
     ///     - `tick_spacing` - The spacing between ticks for the liquidity pool.
@@ -102,10 +102,7 @@ trait IFactory<TContractState> {
     ///
     fn launch_on_ekubo(
         ref self: TContractState,
-        memecoin_address: ContractAddress,
-        transfer_restriction_delay: u64,
-        max_percentage_buy_launch: u16,
-        quote_address: ContractAddress,
+        launch_parameters: LaunchParameters,
         ekubo_parameters: EkuboPoolParameters,
     ) -> (u64, EkuboLP);
 

--- a/contracts/src/factory/interface.cairo
+++ b/contracts/src/factory/interface.cairo
@@ -32,8 +32,6 @@ trait IFactory<TContractState> {
         name: felt252,
         symbol: felt252,
         initial_supply: u256,
-        initial_holders: Span<ContractAddress>,
-        initial_holders_amounts: Span<u256>,
         contract_address_salt: felt252
     ) -> ContractAddress;
 

--- a/contracts/src/tests/addresses.cairo
+++ b/contracts/src/tests/addresses.cairo
@@ -40,3 +40,7 @@ fn EKUBO_REGISTRY() -> ContractAddress {
 fn EKUBO_NFT_CLASS_HASH() -> ClassHash {
     0x034a6f8fbc43c018805c0d73486f7c8e819c12116e6fbaf846e58b9b8b63c27e.try_into().unwrap()
 }
+
+fn EKUBO_ROUTER() -> ContractAddress {
+    0x01b6f560def289b32e2a7b0920909615531a4d9d5636ca509045843559dc23d5.try_into().unwrap()
+}

--- a/contracts/src/tests/fork_tests/test_ekubo.cairo
+++ b/contracts/src/tests/fork_tests/test_ekubo.cairo
@@ -62,7 +62,6 @@ fn launch_memecoin_on_ekubo(
     ERC20ABIDispatcher { contract_address: quote_address }
         .transfer(factory.contract_address, quote_to_deposit);
     stop_prank(CheatTarget::One(quote_address));
-    println!("quote_address");
 
     let (id, position) = factory
         .launch_on_ekubo(
@@ -318,7 +317,7 @@ fn test_launch_meme_token0_price_below_1() {
     let (quote, quote_address) = deploy_eth_with_owner(owner);
     let starting_price = i129 { sign: true, mag: 4600158 }; // 0.01ETH/MEME
     let quote_to_deposit = PercentageMath::percent_mul(
-        21_000 * pow_256(10, 18), 10_150
+        2_100_000 * pow_256(10, 16), 10_120
     ); // 10% of the total supply at a price of 0.01ETH/MEME
     // accounting for the 0.6% tick spacing
 

--- a/contracts/src/tests/fork_tests/test_ekubo.cairo
+++ b/contracts/src/tests/fork_tests/test_ekubo.cairo
@@ -19,8 +19,7 @@ use unruggable::exchanges::ekubo::launcher::{
     IEkuboLauncherDispatcher, IEkuboLauncherDispatcherTrait, EkuboLP
 };
 use unruggable::exchanges::ekubo_adapter::EkuboPoolParameters;
-use unruggable::factory::interface::{IFactoryDispatcher, IFactoryDispatcherTrait};
-use unruggable::factory::{Factory};
+use unruggable::factory::{IFactoryDispatcher, IFactoryDispatcherTrait, Factory, LaunchParameters};
 use unruggable::locker::LockPosition;
 use unruggable::locker::interface::{ILockManagerDispatcher, ILockManagerDispatcherTrait};
 use unruggable::tests::addresses::{EKUBO_CORE};
@@ -51,10 +50,12 @@ fn launch_memecoin_on_ekubo(
 
     let (id, position) = factory
         .launch_on_ekubo(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            quote_address,
+            LaunchParameters {
+                memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address,
+            },
             EkuboPoolParameters { fee, tick_spacing, starting_tick, bound }
         );
 
@@ -613,10 +614,12 @@ fn test_cant_launch_twice() {
     // This will fail as the ownership of the memecoin has been renounced.
     let (id, position) = factory
         .launch_on_ekubo(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            quote_address,
+            LaunchParameters {
+                memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address,
+            },
             EkuboPoolParameters {
                 fee: 0xc49ba5e353f7d00000000000000000,
                 tick_spacing: 5982,
@@ -645,10 +648,12 @@ fn test_launch_memecoin_not_unruggable_ekubo() {
     // This will fail as the ownership of the memecoin has been renounced.
     let (id, position) = factory
         .launch_on_ekubo(
-            fake_memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            quote_address,
+            LaunchParameters {
+                memecoin_address: fake_memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address,
+            },
             EkuboPoolParameters {
                 fee: 0xc49ba5e353f7d00000000000000000,
                 tick_spacing: 5982,
@@ -693,10 +698,12 @@ fn test_launch_memecoin_quote_memecoin_ekubo() {
     start_prank(CheatTarget::One(factory.contract_address), owner);
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            quote.contract_address,
+            LaunchParameters {
+                memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address: quote.contract_address,
+            },
             quote_amount,
             DEFAULT_MIN_LOCKTIME,
         );

--- a/contracts/src/tests/fork_tests/test_ekubo.cairo
+++ b/contracts/src/tests/fork_tests/test_ekubo.cairo
@@ -58,16 +58,11 @@ fn launch_memecoin_on_ekubo(
     let factory = IFactoryDispatcher { contract_address: MEMEFACTORY_ADDRESS() };
     let ekubo_launcher = IEkuboLauncherDispatcher { contract_address: EKUBO_LAUNCHER_ADDRESS() };
 
-    println!("quote to deposit: {}", quote_to_deposit);
-    println!(
-        "quote balance: {}",
-        ERC20ABIDispatcher { contract_address: quote_address }.balance_of(owner)
-    );
     start_prank(CheatTarget::One(quote_address), owner);
     ERC20ABIDispatcher { contract_address: quote_address }
         .transfer(factory.contract_address, quote_to_deposit);
     stop_prank(CheatTarget::One(quote_address));
-    println!("Starting launch");
+    println!("quote_address");
 
     let (id, position) = factory
         .launch_on_ekubo(
@@ -374,9 +369,6 @@ fn test_launch_meme_token0_price_below_1() {
     ekubo_launcher.withdraw_fees(id, recipient);
     let balance_of_memecoin = memecoin.balance_of(recipient);
     let post_balance_quote = quote.balance_of(recipient);
-    println!("balance of memecoin: {}", balance_of_memecoin);
-    println!("post balance quote: {}", post_balance_quote);
-    println!("pre balance quote: {}", pre_balance_quote);
     let balance_quote_diff = post_balance_quote - pre_balance_quote;
     assert(balance_of_memecoin == 0, 'memecoin shouldnt collect fees');
 //TODO: restore this check
@@ -477,9 +469,8 @@ fn test_launch_meme_token0_price_above_1() {
     let owner = snforge_std::test_address();
     let (quote, quote_address) = deploy_eth_with_owner(owner);
     let starting_price = i129 { sign: false, mag: 4600158 }; // 100quote/MEME
-    //TODO: fix
-    let quote_to_deposit = 400_250_000
-        * pow_256(10, 18); // 10% of the total supply at a price of 100quote/MEME
+    let quote_to_deposit = 2_112_600
+        * pow_256(10, 20); // (10%)*1.006 of the total supply at a price of 100quote/MEME
     let (memecoin_address, id, position) = launch_memecoin_on_ekubo(
         quote_address,
         0xc49ba5e353f7d00000000000000000,
@@ -565,8 +556,8 @@ fn test_launch_meme_token1_price_above_1() {
     let owner = snforge_std::test_address();
     let (quote, quote_address) = deploy_token0_with_owner(owner);
     let starting_price = i129 { sign: false, mag: 4600158 }; // 100quote/MEME
-    let quote_to_deposit = 400_000_000
-        * pow_256(10, 18); // 10% of the total supply at a price of 0.01ETH/MEME
+    let quote_to_deposit = 2_112_600
+        * pow_256(10, 20); // (10%)*1.006 of the total supply at a price of 100quote/MEME
     let (memecoin_address, id, position) = launch_memecoin_on_ekubo(
         quote_address,
         0xc49ba5e353f7d00000000000000000,

--- a/contracts/src/tests/fork_tests/test_ekubo.cairo
+++ b/contracts/src/tests/fork_tests/test_ekubo.cairo
@@ -55,6 +55,8 @@ fn launch_memecoin_on_ekubo(
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
                 quote_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             EkuboPoolParameters { fee, tick_spacing, starting_tick, bound }
         );
@@ -619,6 +621,8 @@ fn test_cant_launch_twice() {
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
                 quote_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             EkuboPoolParameters {
                 fee: 0xc49ba5e353f7d00000000000000000,
@@ -653,6 +657,8 @@ fn test_launch_memecoin_not_unruggable_ekubo() {
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
                 quote_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             EkuboPoolParameters {
                 fee: 0xc49ba5e353f7d00000000000000000,
@@ -680,8 +686,6 @@ fn test_launch_memecoin_quote_memecoin_ekubo() {
             name: NAME(),
             symbol: SYMBOL(),
             initial_supply: DEFAULT_INITIAL_SUPPLY(),
-            initial_holders: INITIAL_HOLDERS(),
-            initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             contract_address_salt: SALT() + 1,
         );
     stop_prank(CheatTarget::One(factory.contract_address));
@@ -703,6 +707,8 @@ fn test_launch_memecoin_quote_memecoin_ekubo() {
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
                 quote_address: quote.contract_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             quote_amount,
             DEFAULT_MIN_LOCKTIME,

--- a/contracts/src/tests/fork_tests/test_jediswap.cairo
+++ b/contracts/src/tests/fork_tests/test_jediswap.cairo
@@ -13,7 +13,8 @@ use unruggable::tests::addresses::{JEDI_FACTORY_ADDRESS, JEDI_ROUTER_ADDRESS, ET
 use unruggable::tests::fork_tests::utils::{deploy_memecoin_through_factory_with_owner, sort_tokens};
 use unruggable::tests::unit_tests::utils::{
     OWNER, DEFAULT_MIN_LOCKTIME, pow_256, LOCK_MANAGER_ADDRESS, MEMEFACTORY_ADDRESS,
-    deploy_eth_with_owner, TRANSFER_RESTRICTION_DELAY, MAX_PERCENTAGE_BUY_LAUNCH
+    deploy_eth_with_owner, TRANSFER_RESTRICTION_DELAY, MAX_PERCENTAGE_BUY_LAUNCH, INITIAL_HOLDERS,
+    INITIAL_HOLDERS_AMOUNTS
 };
 use unruggable::token::interface::{IUnruggableMemecoinDispatcherTrait};
 use unruggable::token::memecoin::LiquidityType;
@@ -44,17 +45,19 @@ use unruggable::utils::math::PercentageMath;
 //     quote.approve(factory.contract_address, amount);
 //     stop_prank(CheatTarget::One(quote.contract_address));
 
-    // let pair_address = factory
-    //     .launch_on_jediswap(
-    //         LaunchParameters {
-    //             memecoin_address,
-    //             transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
-    //             max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
-    //             quote_address,
-    //         },
-    //         amount,
-    //         unlock_time
-    //     );
+// let pair_address = factory
+//     .launch_on_jediswap(
+//         LaunchParameters {
+//             memecoin_address,
+//             transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+//             max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+//             quote_address,
+//             initial_holders: INITIAL_HOLDERS(),
+//             initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
+//         },
+//         amount,
+//         unlock_time
+//     );
 
 //     let pair = IJediswapPairDispatcher { contract_address: pair_address };
 
@@ -131,6 +134,8 @@ fn test_buy_above_max_limit_should_fail() {
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
                 quote_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             amount,
             unlock_time

--- a/contracts/src/tests/fork_tests/test_jediswap.cairo
+++ b/contracts/src/tests/fork_tests/test_jediswap.cairo
@@ -6,7 +6,7 @@ use unruggable::exchanges::jediswap_adapter::{
     IJediswapFactoryDispatcher, IJediswapFactoryDispatcherTrait, IJediswapRouterDispatcher,
     IJediswapRouterDispatcherTrait, IJediswapPairDispatcher, IJediswapPairDispatcherTrait,
 };
-use unruggable::factory::interface::{IFactoryDispatcher, IFactoryDispatcherTrait};
+use unruggable::factory::{IFactoryDispatcher, IFactoryDispatcherTrait, LaunchParameters};
 use unruggable::locker::LockPosition;
 use unruggable::locker::interface::{ILockManagerDispatcher, ILockManagerDispatcherTrait};
 use unruggable::tests::addresses::{JEDI_FACTORY_ADDRESS, JEDI_ROUTER_ADDRESS, ETH_ADDRESS};
@@ -44,15 +44,17 @@ use unruggable::utils::math::PercentageMath;
 //     quote.approve(factory.contract_address, amount);
 //     stop_prank(CheatTarget::One(quote.contract_address));
 
-//     let pair_address = factory
-//         .launch_on_jediswap(
-//             memecoin_address,
-//             TRANSFER_RESTRICTION_DELAY,
-//             MAX_PERCENTAGE_BUY_LAUNCH,
-//             quote_address,
-//             amount,
-//             unlock_time
-//         );
+    // let pair_address = factory
+    //     .launch_on_jediswap(
+    //         LaunchParameters {
+    //             memecoin_address,
+    //             transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+    //             max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+    //             quote_address,
+    //         },
+    //         amount,
+    //         unlock_time
+    //     );
 
 //     let pair = IJediswapPairDispatcher { contract_address: pair_address };
 
@@ -124,10 +126,12 @@ fn test_buy_above_max_limit_should_fail() {
 
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            quote_address,
+            LaunchParameters {
+                memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address,
+            },
             amount,
             unlock_time
         );

--- a/contracts/src/tests/fork_tests/utils.cairo
+++ b/contracts/src/tests/fork_tests/utils.cairo
@@ -14,7 +14,8 @@ use unruggable::tests::addresses::{
 };
 use unruggable::tests::unit_tests::utils::{
     deploy_locker, deploy_eth_with_owner, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, INITIAL_HOLDERS,
-    INITIAL_HOLDERS_AMOUNTS, SALT, DefaultTxInfoMock, OWNER, TOKEN0_ADDRESS, MEMEFACTORY_ADDRESS
+    INITIAL_HOLDERS_AMOUNTS, SALT, DefaultTxInfoMock, OWNER, TOKEN0_ADDRESS, MEMEFACTORY_ADDRESS,
+    ETH_INITIAL_SUPPLY
 };
 use unruggable::token::interface::{
     IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
@@ -35,7 +36,7 @@ fn EKUBO_ROUTER_ADDRESS() -> ContractAddress {
 fn deploy_token0_with_owner(owner: ContractAddress) -> (ERC20ABIDispatcher, ContractAddress) {
     let token = declare('ERC20Token');
     let mut calldata = Default::default();
-    Serde::serialize(@DEFAULT_INITIAL_SUPPLY(), ref calldata);
+    Serde::serialize(@ETH_INITIAL_SUPPLY(), ref calldata);
     Serde::serialize(@owner, ref calldata);
 
     let address = token.deploy_at(@calldata, TOKEN0_ADDRESS()).unwrap();

--- a/contracts/src/tests/fork_tests/utils.cairo
+++ b/contracts/src/tests/fork_tests/utils.cairo
@@ -10,7 +10,7 @@ use unruggable::exchanges::SupportedExchanges;
 use unruggable::factory::interface::{IFactoryDispatcher, IFactoryDispatcherTrait};
 use unruggable::tests::addresses::{
     JEDI_FACTORY_ADDRESS, JEDI_ROUTER_ADDRESS, EKUBO_CORE, EKUBO_POSITIONS, EKUBO_REGISTRY,
-    EKUBO_NFT_CLASS_HASH, ETH_ADDRESS
+    EKUBO_NFT_CLASS_HASH, ETH_ADDRESS, EKUBO_ROUTER
 };
 use unruggable::tests::unit_tests::utils::{
     deploy_locker, deploy_eth_with_owner, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, INITIAL_HOLDERS,
@@ -55,6 +55,7 @@ fn deploy_ekubo_launcher() -> ContractAddress {
     Serde::serialize(@EKUBO_CORE(), ref calldata);
     Serde::serialize(@EKUBO_REGISTRY(), ref calldata);
     Serde::serialize(@EKUBO_POSITIONS(), ref calldata);
+    Serde::serialize(@EKUBO_ROUTER(), ref calldata);
 
     launcher
         .deploy_at(@calldata, EKUBO_LAUNCHER_ADDRESS())

--- a/contracts/src/tests/fork_tests/utils.cairo
+++ b/contracts/src/tests/fork_tests/utils.cairo
@@ -99,8 +99,6 @@ fn deploy_memecoin_through_factory_with_owner(
             name: NAME(),
             symbol: SYMBOL(),
             initial_supply: DEFAULT_INITIAL_SUPPLY(),
-            initial_holders: INITIAL_HOLDERS(),
-            initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             contract_address_salt: SALT(),
         );
     stop_prank(CheatTarget::One(memecoin_factory.contract_address));

--- a/contracts/src/tests/unit_tests/test_factory.cairo
+++ b/contracts/src/tests/unit_tests/test_factory.cairo
@@ -143,12 +143,12 @@ fn test_launch_memecoin_happy_path() {
     assert(memecoin.is_launched(), 'should be launched');
 
     // Check pair creation
-    let team_alloc = sum(INITIAL_HOLDERS_AMOUNTS());
+    let team_allocation = sum(INITIAL_HOLDERS_AMOUNTS());
     let pair = IJediswapPairDispatcher { contract_address: pair_address };
     let (token_0_reserves, token_1_reserves, _) = pair.get_reserves();
     assert(pair.token0() == memecoin_address, 'wrong token 0 address');
     assert(pair.token1() == eth.contract_address, 'wrong token 1 address');
-    assert(token_0_reserves == factory_balance_meme - team_alloc, 'wrong pool token reserves');
+    assert(token_0_reserves == factory_balance_meme - team_allocation, 'wrong pool token reserves');
     assert(token_1_reserves == eth_amount, 'wrong pool memecoin reserves');
     let lp_token = ERC20ABIDispatcher { contract_address: pair_address };
     assert(lp_token.balanceOf(memecoin_address) == 0, 'shouldnt have lp tokens');
@@ -395,7 +395,7 @@ fn test_launch_memecoin_amm_not_whitelisted() {
                 initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             EkuboPoolParameters {
-                fee: 0, tick_spacing: 0, starting_tick: i129 { sign: false, mag: 0 }, bound: 0
+                fee: 0, tick_spacing: 0, starting_price: i129 { sign: false, mag: 0 }, bound: 0
             }
         );
 }

--- a/contracts/src/tests/unit_tests/test_factory.cairo
+++ b/contracts/src/tests/unit_tests/test_factory.cairo
@@ -96,8 +96,6 @@ fn test_create_memecoin() {
             name: NAME(),
             symbol: SYMBOL(),
             initial_supply: DEFAULT_INITIAL_SUPPLY(),
-            initial_holders: INITIAL_HOLDERS(),
-            initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             contract_address_salt: SALT(),
         );
     stop_prank(CheatTarget::One(memecoin_factory.contract_address));
@@ -106,20 +104,7 @@ fn test_create_memecoin() {
 
     assert(memecoin.name() == NAME(), 'wrong memecoin name');
     assert(memecoin.symbol() == SYMBOL(), 'wrong memecoin symbol');
-    // initial supply - initial holder balance
-    let holders_sum = *INITIAL_HOLDERS_AMOUNTS()[0] + *INITIAL_HOLDERS_AMOUNTS()[1];
-    assert(
-        memecoin.balanceOf(memecoin_factory_address) == DEFAULT_INITIAL_SUPPLY() - holders_sum,
-        'wrong initial supply'
-    );
-    assert(
-        memecoin.balanceOf(*INITIAL_HOLDERS()[0]) == *INITIAL_HOLDERS_AMOUNTS()[0],
-        'wrong initial_holder_1 balance'
-    );
-    assert(
-        memecoin.balanceOf(*INITIAL_HOLDERS()[1]) == *INITIAL_HOLDERS_AMOUNTS()[1],
-        'wrong initial_holder_2 balance'
-    );
+    assert_eq!(memecoin.balanceOf(memecoin_factory_address), DEFAULT_INITIAL_SUPPLY(),);
 }
 
 #[test]
@@ -145,6 +130,8 @@ fn test_launch_memecoin_happy_path() {
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
                 quote_address: eth.contract_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             eth_amount,
             DEFAULT_MIN_LOCKTIME,
@@ -209,6 +196,8 @@ fn test_launch_memecoin_pair_exists_should_succeed() {
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
                 quote_address: eth.contract_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             eth_amount,
             DEFAULT_MIN_LOCKTIME,
@@ -268,6 +257,8 @@ fn test_launch_memecoin_already_launched() {
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
                 quote_address: eth.contract_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             eth_amount,
             DEFAULT_MIN_LOCKTIME,
@@ -301,6 +292,8 @@ fn test_launch_memecoin_not_unruggable_jediswap() {
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
                 quote_address: eth.contract_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             eth_amount,
             DEFAULT_MIN_LOCKTIME,
@@ -331,6 +324,8 @@ fn test_launch_memecoin_with_percentage_buy_launch_too_low() {
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: 49, // 0.49%
                 quote_address: eth.contract_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             eth_amount,
             DEFAULT_MIN_LOCKTIME,
@@ -348,7 +343,9 @@ fn test_launch_memecoin_not_owner() {
                 memecoin_address,
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
-                quote_address: ETH_ADDRESS()
+                quote_address: ETH_ADDRESS(),
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             1,
             DEFAULT_MIN_LOCKTIME,
@@ -370,8 +367,6 @@ fn test_launch_memecoin_quote_memecoin_jedsiwap() {
             name: NAME(),
             symbol: SYMBOL(),
             initial_supply: DEFAULT_INITIAL_SUPPLY(),
-            initial_holders: INITIAL_HOLDERS(),
-            initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             contract_address_salt: SALT() + 1,
         );
     stop_prank(CheatTarget::One(factory.contract_address));
@@ -392,7 +387,9 @@ fn test_launch_memecoin_quote_memecoin_jedsiwap() {
                 memecoin_address,
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
-                quote_address: quote.contract_address
+                quote_address: quote.contract_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             quote_amount,
             DEFAULT_MIN_LOCKTIME,
@@ -416,7 +413,9 @@ fn test_launch_memecoin_amm_not_whitelisted() {
                 memecoin_address,
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
-                quote_address: eth.contract_address
+                quote_address: eth.contract_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             EkuboPoolParameters {
                 fee: 0, tick_spacing: 0, starting_tick: i129 { sign: false, mag: 0 }, bound: 0

--- a/contracts/src/tests/unit_tests/test_factory.cairo
+++ b/contracts/src/tests/unit_tests/test_factory.cairo
@@ -11,7 +11,7 @@ use unruggable::exchanges::jediswap_adapter::{
     IJediswapPairDispatcherTrait
 };
 use unruggable::exchanges::{SupportedExchanges};
-use unruggable::factory::{IFactory, IFactoryDispatcher, IFactoryDispatcherTrait};
+use unruggable::factory::{IFactory, IFactoryDispatcher, IFactoryDispatcherTrait, LaunchParameters};
 use unruggable::locker::interface::{ILockManagerDispatcher, ILockManagerDispatcherTrait};
 use unruggable::locker::{LockPosition};
 use unruggable::tests::addresses::{ETH_ADDRESS, JEDI_FACTORY_ADDRESS};
@@ -140,10 +140,12 @@ fn test_launch_memecoin_happy_path() {
     start_warp(CheatTarget::One(memecoin_address), 1);
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            eth.contract_address,
+            LaunchParameters {
+                memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address: eth.contract_address,
+            },
             eth_amount,
             DEFAULT_MIN_LOCKTIME,
         );
@@ -202,10 +204,12 @@ fn test_launch_memecoin_pair_exists_should_succeed() {
     start_warp(CheatTarget::One(memecoin_address), 1);
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            eth.contract_address,
+            LaunchParameters {
+                memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address: eth.contract_address,
+            },
             eth_amount,
             DEFAULT_MIN_LOCKTIME,
         );
@@ -259,10 +263,12 @@ fn test_launch_memecoin_already_launched() {
     start_prank(CheatTarget::One(factory.contract_address), OWNER());
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            eth.contract_address,
+            LaunchParameters {
+                memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address: eth.contract_address,
+            },
             eth_amount,
             DEFAULT_MIN_LOCKTIME,
         );
@@ -290,10 +296,12 @@ fn test_launch_memecoin_not_unruggable_jediswap() {
     start_prank(CheatTarget::One(factory.contract_address), OWNER());
     let pair_address = factory
         .launch_on_jediswap(
-            other_token_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            eth.contract_address,
+            LaunchParameters {
+                memecoin_address: other_token_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address: eth.contract_address,
+            },
             eth_amount,
             DEFAULT_MIN_LOCKTIME,
         );
@@ -318,10 +326,12 @@ fn test_launch_memecoin_with_percentage_buy_launch_too_low() {
     start_prank(CheatTarget::One(factory.contract_address), owner);
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            49, // 0.49%
-            eth.contract_address,
+            LaunchParameters {
+                memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: 49, // 0.49%
+                quote_address: eth.contract_address,
+            },
             eth_amount,
             DEFAULT_MIN_LOCKTIME,
         );
@@ -334,10 +344,12 @@ fn test_launch_memecoin_not_owner() {
     let factory = IFactoryDispatcher { contract_address: MEMEFACTORY_ADDRESS() };
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            ETH_ADDRESS(),
+            LaunchParameters {
+                memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address: ETH_ADDRESS()
+            },
             1,
             DEFAULT_MIN_LOCKTIME,
         );
@@ -376,10 +388,12 @@ fn test_launch_memecoin_quote_memecoin_jedsiwap() {
     start_prank(CheatTarget::One(factory.contract_address), owner);
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            quote.contract_address,
+            LaunchParameters {
+                memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address: quote.contract_address
+            },
             quote_amount,
             DEFAULT_MIN_LOCKTIME,
         );
@@ -398,10 +412,12 @@ fn test_launch_memecoin_amm_not_whitelisted() {
 
     let pool_address = factory
         .launch_on_ekubo(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            eth.contract_address,
+            LaunchParameters {
+                memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address: eth.contract_address
+            },
             EkuboPoolParameters {
                 fee: 0, tick_spacing: 0, starting_tick: i129 { sign: false, mag: 0 }, bound: 0
             }

--- a/contracts/src/tests/unit_tests/test_jediswap_integration.cairo
+++ b/contracts/src/tests/unit_tests/test_jediswap_integration.cairo
@@ -10,7 +10,7 @@ use unruggable::exchanges::jediswap_adapter::{
     IJediswapFactoryDispatcher, IJediswapFactoryDispatcherTrait, IJediswapRouterDispatcher,
     IJediswapRouterDispatcherTrait, IJediswapPairDispatcher, IJediswapPairDispatcherTrait,
 };
-use unruggable::factory::interface::{IFactoryDispatcher, IFactoryDispatcherTrait};
+use unruggable::factory::{LaunchParameters, IFactoryDispatcher, IFactoryDispatcherTrait};
 use unruggable::locker::interface::{
     ILockManagerDispatcher, ILockManagerDispatcherTrait, LockPosition
 };
@@ -19,7 +19,7 @@ use unruggable::tests::unit_tests::utils::{
     deploy_memecoin_through_factory_with_owner, TRANSFER_RESTRICTION_DELAY,
     MAX_PERCENTAGE_BUY_LAUNCH, deploy_eth_with_owner, MEMEFACTORY_ADDRESS, LOCK_MANAGER_ADDRESS,
     DEFAULT_MIN_LOCKTIME, pow_256, deploy_jedi_amm_factory_and_router, deploy_meme_factory,
-    deploy_eth, ETH_ADDRESS
+    deploy_eth, ETH_ADDRESS, INITIAL_HOLDERS, INITIAL_HOLDERS_AMOUNTS
 };
 use unruggable::token::interface::{
     IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
@@ -45,10 +45,14 @@ fn test_jediswap_integration() {
     start_warp(CheatTarget::One(memecoin_address), 1);
     let pair_address = factory
         .launch_on_jediswap(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            eth.contract_address,
+            LaunchParameters {
+                memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address: eth.contract_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
+            },
             eth_amount,
             DEFAULT_MIN_LOCKTIME,
         );

--- a/contracts/src/tests/unit_tests/test_lock_manager.cairo
+++ b/contracts/src/tests/unit_tests/test_lock_manager.cairo
@@ -10,7 +10,7 @@ use starknet::{ContractAddress, contract_address_const};
 use unruggable::locker::{errors, LockManager, ILockManagerDispatcher, ILockManagerDispatcherTrait};
 use unruggable::tests::unit_tests::utils::{
     OWNER, deploy_eth, deploy_locker, DEFAULT_MIN_LOCKTIME, LOCK_POSITION_ADDRESS,
-    DEFAULT_INITIAL_SUPPLY, DEFAULT_LOCK_AMOUNT
+    DEFAULT_INITIAL_SUPPLY, DEFAULT_LOCK_AMOUNT, ETH_INITIAL_SUPPLY
 };
 use unruggable::token::interface::{
     IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
@@ -124,7 +124,7 @@ mod test_lock {
         setup, setup_and_lock, ILockManagerDispatcher, ILockManagerDispatcherTrait, OWNER,
         deploy_locker, start_prank, stop_prank, CheatTarget, ERC20ABIDispatcherTrait,
         DEFAULT_LOCK_AMOUNT, DEFAULT_MIN_LOCKTIME, spy_events, SpyOn, EventSpy, EventAssertions,
-        LockManager, DEFAULT_INITIAL_SUPPLY
+        LockManager, DEFAULT_INITIAL_SUPPLY, ETH_INITIAL_SUPPLY
     };
 
     #[test]
@@ -153,7 +153,7 @@ mod test_lock {
         // Check token balances
         let owner_balance = token.balanceOf(OWNER());
         assert(
-            owner_balance == DEFAULT_INITIAL_SUPPLY() - DEFAULT_LOCK_AMOUNT,
+            owner_balance == ETH_INITIAL_SUPPLY() - DEFAULT_LOCK_AMOUNT,
             'owner balance is incorrect'
         );
         let locker_balance = token.balanceOf(lock_address);
@@ -420,7 +420,7 @@ mod test_withdrawal {
         LockManager,
     };
     use unruggable::locker::{LockPosition, TokenLock};
-    use unruggable::tests::unit_tests::utils::DEFAULT_INITIAL_SUPPLY;
+    use unruggable::tests::unit_tests::utils::{ETH_INITIAL_SUPPLY, DEFAULT_INITIAL_SUPPLY};
 
     #[test]
     fn test_withdraw() {
@@ -558,7 +558,7 @@ mod test_withdrawal {
         // Check token balances
         let owner_balance = token.balanceOf(OWNER());
         assert(
-            owner_balance == DEFAULT_INITIAL_SUPPLY() - DEFAULT_LOCK_AMOUNT + partial_amount,
+            owner_balance == ETH_INITIAL_SUPPLY() - DEFAULT_LOCK_AMOUNT + partial_amount,
             'owner balance is incorrect'
         );
         let locker_balance = token.balanceOf(lock_address);

--- a/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
+++ b/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
@@ -154,9 +154,9 @@ mod memecoin_entrypoints {
         let (memecoin, memecoin_address) = deploy_memecoin_through_factory();
         store(memecoin_address, selector!("team_allocation"), array![2_100_000].span());
 
-        let team_alloc = memecoin.get_team_allocation();
+        let team_allocation = memecoin.get_team_allocation();
         // Team alloc is set to 10% in test utils
-        assert_eq!(team_alloc, 2_100_000);
+        assert_eq!(team_allocation, 2_100_000);
     }
 
     #[test]

--- a/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
+++ b/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
@@ -3,7 +3,7 @@ use openzeppelin::utils::serde::SerializedAppend;
 
 use snforge_std::{
     declare, ContractClassTrait, start_prank, stop_prank, RevertedTransaction, CheatTarget,
-    TxInfoMock,
+    TxInfoMock, store, map_entry_address
 };
 use starknet::contract_address::ContractAddressZeroable;
 use starknet::{ContractAddress, contract_address_const};
@@ -49,29 +49,19 @@ mod test_constructor {
         // Deployer must be the meme factory
         start_prank(CheatTarget::One(snforge_std::test_address()), MEMEFACTORY_ADDRESS());
         UnruggableMemecoin::constructor(
-            ref memecoin,
-            OWNER(),
-            NAME(),
-            SYMBOL(),
-            DEFAULT_INITIAL_SUPPLY(),
-            INITIAL_HOLDERS(),
-            INITIAL_HOLDERS_AMOUNTS()
+            ref memecoin, OWNER(), NAME(), SYMBOL(), DEFAULT_INITIAL_SUPPLY(),
         );
 
         // External entrypoints
         assert(
             memecoin.memecoin_factory_address() == MEMEFACTORY_ADDRESS(), 'wrong factory address'
         );
-
-        // Check internals that must be set upon deployment
-        assert(
-            memecoin.team_allocation.read() == 2_100_000 * pow_256(10, 18), 'wrong team allocation'
-        ); // 10% of supply
     }
 
+    //TODO:move
     #[test]
     #[should_panic(expected: ('Holders len dont match amounts',))]
-    fn test_constructor_initial_holders_arrays_len_mismatch() {
+    fn test_launch_initial_holders_arrays_len_mismatch() {
         let initial_holders: Array<ContractAddress> = array![
             INITIAL_HOLDER_1(),
             INITIAL_HOLDER_2(),
@@ -81,16 +71,11 @@ mod test_constructor {
         let initial_holders_amounts: Array<u256> = array![50, 40, 10];
         let mut state = UnruggableMemecoin::contract_state_for_testing();
         UnruggableMemecoin::constructor(
-            ref state,
-            OWNER(),
-            NAME(),
-            SYMBOL(),
-            DEFAULT_INITIAL_SUPPLY(),
-            initial_holders.span(),
-            initial_holders_amounts.span()
+            ref state, OWNER(), NAME(), SYMBOL(), DEFAULT_INITIAL_SUPPLY(),
         );
     }
 
+    //TODO: move
     #[test]
     #[should_panic(expected: ('Max number of holders reached',))]
     fn test_constructor_max_holders_reached() {
@@ -111,16 +96,11 @@ mod test_constructor {
         let initial_holders_amounts: Array<u256> = array![1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
         let mut state = UnruggableMemecoin::contract_state_for_testing();
         UnruggableMemecoin::constructor(
-            ref state,
-            OWNER(),
-            NAME(),
-            SYMBOL(),
-            DEFAULT_INITIAL_SUPPLY(),
-            initial_holders.span(),
-            initial_holders_amounts.span()
+            ref state, OWNER(), NAME(), SYMBOL(), DEFAULT_INITIAL_SUPPLY(),
         );
     }
 
+    //TODO: move
     #[test]
     #[should_panic(expected: ('Max team allocation reached',))]
     fn test_constructor_too_much_team_alloc_should_fail() {
@@ -130,13 +110,7 @@ mod test_constructor {
         let alloc_holder_2 = 1_050_001 * pow_256(10, 18);
         let mut state = UnruggableMemecoin::contract_state_for_testing();
         UnruggableMemecoin::constructor(
-            ref state,
-            OWNER(),
-            NAME(),
-            SYMBOL(),
-            DEFAULT_INITIAL_SUPPLY(),
-            INITIAL_HOLDERS(),
-            array![alloc_holder_1, alloc_holder_2].span()
+            ref state, OWNER(), NAME(), SYMBOL(), DEFAULT_INITIAL_SUPPLY(),
         );
     }
 }
@@ -150,7 +124,7 @@ mod memecoin_entrypoints {
     };
     use snforge_std::{
         declare, ContractClassTrait, start_prank, stop_prank, CheatTarget, start_warp, stop_warp,
-        TxInfoMock
+        TxInfoMock, store, map_entry_address
     };
     use starknet::{ContractAddress, contract_address_const};
     use unruggable::exchanges::{SupportedExchanges};
@@ -178,10 +152,11 @@ mod memecoin_entrypoints {
     #[test]
     fn test_get_team_allocation() {
         let (memecoin, memecoin_address) = deploy_memecoin_through_factory();
+        store(memecoin_address, selector!("team_allocation"), array![2_100_000].span());
 
         let team_alloc = memecoin.get_team_allocation();
         // Team alloc is set to 10% in test utils
-        assert(team_alloc == 2_100_000 * pow_256(10, 18), 'Invalid team allocation');
+        assert_eq!(team_alloc, 2_100_000);
     }
 
     #[test]
@@ -196,42 +171,61 @@ mod memecoin_entrypoints {
     #[test]
     fn test_transfer_max_percentage_not_pair_should_succeed() {
         let (memecoin, memecoin_address) = deploy_and_launch_memecoin();
+        let sender = contract_address_const::<'sender'>();
+        store(
+            memecoin_address,
+            map_entry_address(selector!("ERC20_balances"), array![sender.into()].span()),
+            array![2_100_000].span()
+        );
 
         // Transfer slightly more than 2% of 21M stokens from owner to ALICE().
-        let amount = 420_001 * pow_256(10, 18);
-        start_prank(CheatTarget::One(memecoin.contract_address), INITIAL_HOLDER_1());
+        let amount = 420_001;
+        start_prank(CheatTarget::One(memecoin.contract_address), sender);
         let send_amount = memecoin.transfer(ALICE(), amount);
     }
 
     #[test]
     fn test_transfer_from_max_percentage_not_pair_should_succeed() {
         let (memecoin, memecoin_address) = deploy_and_launch_memecoin();
+        let sender = contract_address_const::<'sender'>();
+        store(
+            memecoin_address,
+            map_entry_address(selector!("ERC20_balances"), array![sender.into()].span()),
+            array![2_100_000].span()
+        );
+        let pre_sender_balance = memecoin.balance_of(sender);
 
         let this_address = snforge_std::test_address();
-        let amount = 420_001 * pow_256(10, 18);
+        let amount = 420_001;
 
-        start_prank(CheatTarget::One(memecoin.contract_address), INITIAL_HOLDER_1());
+        start_prank(CheatTarget::One(memecoin.contract_address), sender);
         memecoin.approve(this_address, amount);
         stop_prank(CheatTarget::One(memecoin.contract_address));
 
-        memecoin.transfer_from(INITIAL_HOLDER_1(), ALICE(), amount);
+        memecoin.transfer_from(sender, ALICE(), amount);
     }
 
     #[test]
     fn test_transfer_from_multi_call_not_pair_should_succeed() {
         let (memecoin, memecoin_address) = deploy_and_launch_memecoin();
+        let sender = contract_address_const::<'sender'>();
+        store(
+            memecoin_address,
+            map_entry_address(selector!("ERC20_balances"), array![sender.into()].span()),
+            array![2_100_000].span()
+        );
 
         let this_address = snforge_std::test_address();
 
         // Approvals required for transferFrom
-        start_prank(CheatTarget::One(memecoin_address), INITIAL_HOLDER_1());
+        start_prank(CheatTarget::One(memecoin_address), sender);
         memecoin.approve(this_address, 2);
         stop_prank(CheatTarget::One(memecoin_address));
 
         // Transfer token from owner twice, to ALICE() and to BOB() - should fail because
         // the tx_hash is the same for both calls
-        memecoin.transfer_from(INITIAL_HOLDER_1(), ALICE(), 1);
-        memecoin.transfer_from(INITIAL_HOLDER_1(), BOB(), 1);
+        memecoin.transfer_from(sender, ALICE(), 1);
+        memecoin.transfer_from(sender, BOB(), 1);
     }
 
     #[test]
@@ -254,210 +248,16 @@ mod memecoin_entrypoints {
     #[test]
     fn test_classic_max_percentage() {
         let (memecoin, memecoin_address) = deploy_memecoin_through_factory();
+        let sender = contract_address_const::<'sender'>();
+        store(
+            memecoin_address,
+            map_entry_address(selector!("ERC20_balances"), array![sender.into()].span()),
+            array![2_100_000].span()
+        );
 
         // Transfer 1 token from owner to ALICE().
-        start_prank(CheatTarget::One(memecoin_address), INITIAL_HOLDER_1());
+        start_prank(CheatTarget::One(memecoin_address), sender);
         let send_amount = memecoin.transfer(ALICE(), 20);
         assert(memecoin.balanceOf(ALICE()) == 20, 'Invalid balance');
-    }
-}
-
-
-mod memecoin_internals {
-    use UnruggableMemecoin::{
-        UnruggableMemecoinInternalImpl, SnakeEntrypoints, UnruggableEntrypoints,
-        MAX_HOLDERS_BEFORE_LAUNCH
-    };
-    use core::debug::PrintTrait;
-    use openzeppelin::token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
-    use snforge_std::{declare, ContractClassTrait, start_prank, stop_prank, CheatTarget};
-    use starknet::{ContractAddress, contract_address_const};
-    use super::{TxInfoMock};
-    use unruggable::tests::unit_tests::utils::{
-        deploy_jedi_amm_factory_and_router, deploy_meme_factory, deploy_locker,
-        deploy_eth_with_owner, OWNER, NAME, SYMBOL, DEFAULT_INITIAL_SUPPLY, INITIAL_HOLDERS,
-        INITIAL_HOLDER_1, INITIAL_HOLDER_2, INITIAL_HOLDERS_AMOUNTS, SALT, DefaultTxInfoMock,
-        deploy_memecoin_through_factory, ETH_ADDRESS, deploy_memecoin_through_factory_with_owner,
-        JEDI_ROUTER_ADDRESS, MEMEFACTORY_ADDRESS, ALICE, BOB, deploy_and_launch_memecoin
-    };
-    use unruggable::token::interface::{
-        IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
-    };
-    use unruggable::token::memecoin::{
-        UnruggableMemecoin, UnruggableMemecoin::pre_launch_holders_countContractMemberStateTrait
-    };
-
-    #[test]
-    fn test_transfer_zero_value_doesnt_increment_holders() {
-        // Given
-        let mut memecoin = UnruggableMemecoin::contract_state_for_testing();
-        start_prank(CheatTarget::One(snforge_std::test_address()), MEMEFACTORY_ADDRESS());
-        UnruggableMemecoin::constructor(
-            ref memecoin,
-            OWNER(),
-            NAME(),
-            SYMBOL(),
-            DEFAULT_INITIAL_SUPPLY(),
-            INITIAL_HOLDERS(),
-            INITIAL_HOLDERS_AMOUNTS()
-        );
-        assert_eq!(memecoin.pre_launch_holders_count.read().into(), INITIAL_HOLDERS().len(),);
-
-        // When someone does a zero value transfer there should still be 2 holder
-        let unknown_person = contract_address_const::<'unknown'>();
-        start_prank(CheatTarget::One(snforge_std::test_address()), unknown_person);
-        memecoin.transfer_from(INITIAL_HOLDER_1(), unknown_person, 0);
-
-        // Then the holder count should remain the same
-        assert_eq!(memecoin.pre_launch_holders_count.read().into(), (INITIAL_HOLDERS().len()),);
-    }
-
-    #[test]
-    fn test_transfer_zero_value_doesnt_decrement_holders() {
-        // Given
-        let mut memecoin = UnruggableMemecoin::contract_state_for_testing();
-        start_prank(CheatTarget::One(snforge_std::test_address()), MEMEFACTORY_ADDRESS());
-
-        UnruggableMemecoin::constructor(
-            ref memecoin,
-            OWNER(),
-            NAME(),
-            SYMBOL(),
-            DEFAULT_INITIAL_SUPPLY(),
-            INITIAL_HOLDERS(),
-            INITIAL_HOLDERS_AMOUNTS()
-        );
-        assert_eq!(memecoin.pre_launch_holders_count.read().into(), INITIAL_HOLDERS().len(),);
-
-        // When the sender (the unknown person in this case) has 0 token balance
-        // and the recipient has a non zero token balance
-
-        let unknown_person = contract_address_const::<'unknown'>();
-        start_prank(CheatTarget::One(snforge_std::test_address()), unknown_person);
-        memecoin.transfer(MEMEFACTORY_ADDRESS(), 0);
-
-        // Then the pre launch holders count should not reduces by 1
-        // Then the holder count should remain the same
-        assert_eq!(memecoin.pre_launch_holders_count.read().into(), (INITIAL_HOLDERS().len()),);
-    }
-
-    #[test]
-    fn test__transfer_recipients_equal_holder_cap() {
-        let (memecoin, memecoin_address) = deploy_memecoin_through_factory();
-
-        // set INITIAL_HOLDER_1() as caller to distribute tokens
-        start_prank(CheatTarget::One(memecoin.contract_address), INITIAL_HOLDER_1());
-
-        let mut index = 0;
-        loop {
-            // MAX_HOLDERS_BEFORE_LAUNCH - 2 because there are 2 initial holders
-            if index == MAX_HOLDERS_BEFORE_LAUNCH - 2 {
-                break;
-            }
-
-            // create a unique address
-            let unique_recipient: ContractAddress = (index.into() + 9999).try_into().unwrap();
-
-            // creating and setting unique tx_hash here
-            let mut tx_info: TxInfoMock = Default::default();
-            tx_info.transaction_hash = Option::Some(index.into() + 9999);
-            snforge_std::start_spoof(CheatTarget::One(memecoin.contract_address), tx_info);
-
-            // Transfer 1 token to the unique recipient
-            memecoin.transfer(unique_recipient, 1);
-
-            // Check recipient balance. Should be equal to 1.
-            let recipient_balance = memecoin.balanceOf(unique_recipient);
-            assert(recipient_balance == 1, 'Invalid balance recipient');
-
-            index += 1;
-        };
-    }
-
-    #[test]
-    fn test__transfer_existing_holders() {
-        /// pre launch holder number should not change when
-        /// transfer is done to recipient(s) who already have tokens
-
-        /// to test this, we are going to continuously self transfer tokens
-        /// and ensure that we can transfer more than `MAX_HOLDERS_BEFORE_LAUNCH` times
-
-        let (memecoin, memecoin_address) = deploy_memecoin_through_factory();
-
-        // set INITIAL_HOLDER_1() as caller to distribute tokens
-        start_prank(CheatTarget::One(memecoin.contract_address), INITIAL_HOLDER_1());
-
-        let mut index = 0;
-        loop {
-            if index == MAX_HOLDERS_BEFORE_LAUNCH {
-                break;
-            }
-
-            // creating and setting unique tx_hash here
-            let mut tx_info: TxInfoMock = Default::default();
-            tx_info.transaction_hash = Option::Some(index.into() + 9999);
-            snforge_std::start_spoof(CheatTarget::One(memecoin.contract_address), tx_info);
-
-            // Self transfer tokens
-            memecoin.transfer(INITIAL_HOLDER_2(), 1);
-
-            index += 1;
-        };
-    }
-
-    #[test]
-    #[should_panic(expected: ('Max number of holders reached',))]
-    fn test__transfer_above_holder_cap() {
-        let (memecoin, memecoin_address) = deploy_memecoin_through_factory();
-
-        // set INITIAL_HOLDER_1() as caller to distribute tokens
-        start_prank(CheatTarget::One(memecoin.contract_address), INITIAL_HOLDER_1());
-
-        let mut index = 0;
-        loop {
-            if index == MAX_HOLDERS_BEFORE_LAUNCH {
-                break;
-            }
-
-            // create a unique address
-            let unique_recipient: ContractAddress = (index.into() + 9999).try_into().unwrap();
-
-            // creating and setting unique tx_hash here
-            let mut tx_info: TxInfoMock = Default::default();
-            tx_info.transaction_hash = Option::Some(index.into() + 9999);
-            snforge_std::start_spoof(CheatTarget::One(memecoin.contract_address), tx_info);
-            // Transfer 1 token to the unique recipient
-            memecoin.transfer(unique_recipient, 1);
-
-            index += 1;
-        };
-    }
-
-    #[test]
-    fn test__transfer_no_holder_cap_after_launch() {
-        let (memecoin, memecoin_address) = deploy_and_launch_memecoin();
-        let eth = ERC20ABIDispatcher { contract_address: ETH_ADDRESS() };
-
-        start_prank(CheatTarget::All, INITIAL_HOLDER_1());
-
-        let mut index = 0;
-        loop {
-            if index == MAX_HOLDERS_BEFORE_LAUNCH + 100 {
-                break;
-            }
-
-            // create a unique address
-            let unique_recipient: ContractAddress = (index.into() + 9999).try_into().unwrap();
-
-            // creating and setting unique tx_hash here
-            let mut tx_info: TxInfoMock = Default::default();
-            tx_info.transaction_hash = Option::Some(index.into() + 9999);
-            snforge_std::start_spoof(CheatTarget::One(memecoin.contract_address), tx_info);
-
-            // Transfer 1 token to the unique recipient
-            memecoin.transfer(unique_recipient, 1);
-
-            index += 1;
-        };
     }
 }

--- a/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
+++ b/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
@@ -19,7 +19,6 @@ use unruggable::token::interface::{
 
 mod test_constructor {
     use UnruggableMemecoin::{
-        pre_launch_holders_countContractMemberStateTrait,
         transfer_restriction_delayContractMemberStateTrait, team_allocationContractMemberStateTrait,
         IUnruggableAdditional, IUnruggableMemecoinCamel, IUnruggableMemecoinSnake
     };

--- a/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
+++ b/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
@@ -57,8 +57,9 @@ mod test_constructor {
         );
     }
 
-    //TODO:move
+    //TODO:move to launch
     #[test]
+    #[ignore]
     #[should_panic(expected: ('Holders len dont match amounts',))]
     fn test_launch_initial_holders_arrays_len_mismatch() {
         let initial_holders: Array<ContractAddress> = array![
@@ -74,8 +75,9 @@ mod test_constructor {
         );
     }
 
-    //TODO: move
+    //TODO: move to launch
     #[test]
+    #[ignore]
     #[should_panic(expected: ('Max number of holders reached',))]
     fn test_constructor_max_holders_reached() {
         // 11 holders > 10 holders max
@@ -99,8 +101,9 @@ mod test_constructor {
         );
     }
 
-    //TODO: move
+    //TODO: move to launch
     #[test]
+    #[ignore]
     #[should_panic(expected: ('Max team allocation reached',))]
     fn test_constructor_too_much_team_alloc_should_fail() {
         let mut calldata = array![OWNER().into(), 'locker', NAME().into(), SYMBOL().into()];

--- a/contracts/src/tests/unit_tests/utils.cairo
+++ b/contracts/src/tests/unit_tests/utils.cairo
@@ -6,7 +6,7 @@ use snforge_std::{
 };
 use starknet::ContractAddress;
 use unruggable::exchanges::{SupportedExchanges};
-use unruggable::factory::{IFactoryDispatcher, IFactoryDispatcherTrait};
+use unruggable::factory::{IFactoryDispatcher, IFactoryDispatcherTrait, LaunchParameters};
 use unruggable::tests::addresses::{
     JEDI_ROUTER_ADDRESS, JEDI_FACTORY_ADDRESS, ETH_ADDRESS, EKUBO_CORE, EKUBO_POSITIONS,
     EKUBO_REGISTRY, EKUBO_NFT_CLASS_HASH, TOKEN0_ADDRESS
@@ -279,10 +279,12 @@ fn deploy_and_launch_memecoin() -> (IUnruggableMemecoinDispatcher, ContractAddre
     start_warp(CheatTarget::One(memecoin_address), 1);
     let pool_address = factory
         .launch_on_jediswap(
-            memecoin_address,
-            TRANSFER_RESTRICTION_DELAY,
-            MAX_PERCENTAGE_BUY_LAUNCH,
-            eth.contract_address,
+            LaunchParameters {
+                memecoin_address,
+                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
+                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
+                quote_address: eth.contract_address
+            },
             eth_amount,
             DEFAULT_MIN_LOCKTIME,
         );

--- a/contracts/src/tests/unit_tests/utils.cairo
+++ b/contracts/src/tests/unit_tests/utils.cairo
@@ -108,8 +108,6 @@ fn deploy_standalone_memecoin() -> (IUnruggableMemecoinDispatcher, ContractAddre
     let contract = declare('UnruggableMemecoin');
     let mut calldata = array![OWNER().into(), NAME().into(), SYMBOL().into(),];
     Serde::serialize(@DEFAULT_INITIAL_SUPPLY(), ref calldata);
-    Serde::serialize(@INITIAL_HOLDERS(), ref calldata);
-    Serde::serialize(@INITIAL_HOLDERS_AMOUNTS(), ref calldata);
     let contract_address = contract.deploy(@calldata).expect('failed to deploy memecoin');
     let memecoin = IUnruggableMemecoinDispatcher { contract_address };
 
@@ -240,8 +238,6 @@ fn deploy_memecoin_through_factory_with_owner(
             name: NAME(),
             symbol: SYMBOL(),
             initial_supply: DEFAULT_INITIAL_SUPPLY(),
-            initial_holders: INITIAL_HOLDERS(),
-            initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             contract_address_salt: SALT(),
         );
     stop_prank(CheatTarget::One(memecoin_factory.contract_address));
@@ -283,7 +279,9 @@ fn deploy_and_launch_memecoin() -> (IUnruggableMemecoinDispatcher, ContractAddre
                 memecoin_address,
                 transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
                 max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
-                quote_address: eth.contract_address
+                quote_address: eth.contract_address,
+                initial_holders: INITIAL_HOLDERS(),
+                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
             eth_amount,
             DEFAULT_MIN_LOCKTIME,

--- a/contracts/src/tests/unit_tests/utils.cairo
+++ b/contracts/src/tests/unit_tests/utils.cairo
@@ -74,6 +74,10 @@ fn DEFAULT_INITIAL_SUPPLY() -> u256 {
     21_000_000 * pow_256(10, 18)
 }
 
+fn ETH_INITIAL_SUPPLY() -> u256 {
+    500_000_000 * pow_256(10, 18)
+}
+
 fn LOCK_MANAGER_ADDRESS() -> ContractAddress {
     'lock_manager'.try_into().unwrap()
 }
@@ -199,7 +203,7 @@ fn deploy_eth() -> (ERC20ABIDispatcher, ContractAddress) {
 fn deploy_eth_with_owner(owner: ContractAddress) -> (ERC20ABIDispatcher, ContractAddress) {
     let token = declare('ERC20Token');
     let mut calldata = Default::default();
-    Serde::serialize(@DEFAULT_INITIAL_SUPPLY(), ref calldata);
+    Serde::serialize(@ETH_INITIAL_SUPPLY(), ref calldata);
     Serde::serialize(@owner, ref calldata);
 
     let address = token.deploy_at(@calldata, ETH_ADDRESS()).unwrap();

--- a/contracts/src/token/interface.cairo
+++ b/contracts/src/token/interface.cairo
@@ -55,7 +55,8 @@ trait IUnruggableMemecoin<TState> {
         ref self: TState,
         liquidity_type: LiquidityType,
         transfer_restriction_delay: u64,
-        max_percentage_buy_launch: u16
+        max_percentage_buy_launch: u16,
+        team_allocation: u256,
     );
 }
 
@@ -119,6 +120,7 @@ trait IUnruggableAdditional<TState> {
         ref self: TState,
         liquidity_type: LiquidityType,
         transfer_restriction_delay: u64,
-        max_percentage_buy_launch: u16
+        max_percentage_buy_launch: u16,
+        team_allocation: u256,
     );
 }

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -60,7 +60,6 @@ mod UnruggableMemecoin {
     #[storage]
     struct Storage {
         marker_v_0: (),
-        pre_launch_holders_count: u8,
         team_allocation: u256,
         tx_hash_tracker: LegacyMap<ContractAddress, felt252>,
         transfer_restriction_delay: u64,

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -134,7 +134,8 @@ mod UnruggableMemecoin {
             ref self: ContractState,
             liquidity_type: LiquidityType,
             transfer_restriction_delay: u64,
-            max_percentage_buy_launch: u16
+            max_percentage_buy_launch: u16,
+            team_allocation: u256,
         ) {
             self.assert_only_factory();
             assert(!self.is_launched(), errors::ALREADY_LAUNCHED);
@@ -145,6 +146,7 @@ mod UnruggableMemecoin {
 
             self.liquidity_type.write(Option::Some(liquidity_type));
             self.launch_time.write(get_block_timestamp());
+            self.team_allocation.write(team_allocation);
 
             // Enable a transfer limit - until this time has passed,
             // transfers are limited to a certain amount.

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -41,7 +41,6 @@ mod UnruggableMemecoin {
         IUnruggableMemecoinSnake, IUnruggableMemecoinCamel, IUnruggableAdditional
     };
     use unruggable::utils::math::PercentageMath;
-    use unruggable::utils::unique_count;
 
     // Components.
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -55,13 +54,6 @@ mod UnruggableMemecoin {
     impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
 
     // Constants.
-    /// The maximum number of holders allowed before launch.
-    /// This is to prevent the contract from being is_launched with a large number of holders.
-    /// Once reached, transfers are disabled until the memecoin is is_launched.
-    const MAX_HOLDERS_BEFORE_LAUNCH: u8 = 10;
-    /// The maximum percentage of the total supply that can be allocated to the team.
-    /// This is to prevent the team from having too much control over the supply.
-    const MAX_SUPPLY_PERCENTAGE_TEAM_ALLOCATION: u16 = 1_000; // 10%
     /// The minimum maximum percentage of the supply that can be bought at once.
     const MIN_MAX_PERCENTAGE_BUY_LAUNCH: u16 = 50; // 0.5%
 
@@ -107,8 +99,6 @@ mod UnruggableMemecoin {
         name: felt252,
         symbol: felt252,
         initial_supply: u256,
-        initial_holders: Span<ContractAddress>,
-        initial_holders_amounts: Span<u256>,
     ) {
         assert(owner.is_non_zero(), errors::OWNER_IS_ZERO);
         self.erc20.initializer(name, symbol);
@@ -118,13 +108,7 @@ mod UnruggableMemecoin {
         self.liquidity_type.write(Option::None);
 
         // Initialize the token / internal logic
-        self
-            .initializer(
-                factory_address: get_caller_address(),
-                :initial_supply,
-                :initial_holders,
-                :initial_holders_amounts
-            );
+        self.initializer(factory_address: get_caller_address(), :initial_supply,);
     }
 
     #[abi(embed_v0)]
@@ -253,22 +237,13 @@ mod UnruggableMemecoin {
         /// # Returns
         /// * `u256` - The total amount of memecoin allocated to the team.
         fn initializer(
-            ref self: ContractState,
-            factory_address: ContractAddress,
-            initial_supply: u256,
-            initial_holders: Span<ContractAddress>,
-            initial_holders_amounts: Span<u256>
+            ref self: ContractState, factory_address: ContractAddress, initial_supply: u256,
         ) {
             // Internal Registry
             self.factory_contract.write(factory_address);
 
-            let team_allocation = self
-                .check_and_allocate_team_supply(
-                    :initial_supply, :initial_holders, :initial_holders_amounts
-                );
-
             // Mint remaining supply to the contract
-            self.erc20._mint(recipient: factory_address, amount: initial_supply - team_allocation);
+            self.erc20._mint(recipient: factory_address, amount: initial_supply);
         }
 
         /// Transfers tokens from the sender to the recipient, by applying relevant restrictions.
@@ -312,11 +287,10 @@ mod UnruggableMemecoin {
                 return;
             }
 
+            //TODO(audit): shouldnt ever happen since factory has all the supply
             if !self.is_launched() {
-                self.enforce_prelaunch_holders_limit(sender, recipient, amount);
                 return;
             }
-
             // Safe unwrap as we already checked that the coin is launched,
             // thus the liquidity type is not none.
             match self.liquidity_type.read().unwrap() {
@@ -363,61 +337,6 @@ mod UnruggableMemecoin {
                     + self.transfer_restriction_delay.read())
         }
 
-        /// Checks and allocates the team supply of the memecoin.
-        ///
-        /// Checks that the number of initial holders and their corresponding amounts are equal,
-        /// and that the number of initial holders does not exceed the maximum allowed.
-        /// It then calculates the maximum team allocation as a percentage of the initial supply,
-        /// and iteratively allocates the supply to each initial holder, ensuring that the total allocation does not exceed the maximu authorized.
-        /// The function then updates the `team_allocation` and `pre_launch_holders_count` in the contract state.
-        ///
-        /// # Arguments
-        ///
-        /// * `initial_supply` - The initial supply of the memecoin.
-        /// * `initial_holders` - A span of addresses that will hold the memecoin initially.
-        /// * `initial_holders_amounts` - A span of amounts corresponding to the initial holders.
-        ///
-        /// # Returns
-        ///
-        /// * `u256` - The total amount of memecoin allocated to the team.
-        ///
-        fn check_and_allocate_team_supply(
-            ref self: ContractState,
-            initial_supply: u256,
-            initial_holders: Span<ContractAddress>,
-            initial_holders_amounts: Span<u256>
-        ) -> u256 {
-            assert(initial_holders.len() == initial_holders_amounts.len(), errors::ARRAYS_LEN_DIF);
-            assert(
-                initial_holders.len() <= MAX_HOLDERS_BEFORE_LAUNCH.into(),
-                errors::MAX_HOLDERS_REACHED
-            );
-
-            let max_team_allocation = initial_supply
-                .percent_mul(MAX_SUPPLY_PERCENTAGE_TEAM_ALLOCATION.into());
-            let mut team_allocation: u256 = 0;
-            let mut i: usize = 0;
-            loop {
-                if i == initial_holders.len() {
-                    break;
-                }
-
-                let address = *initial_holders.at(i);
-                let amount = *initial_holders_amounts.at(i);
-
-                team_allocation += amount;
-                assert(team_allocation <= max_team_allocation, errors::MAX_TEAM_ALLOCATION_REACHED);
-
-                // Mint token to the holder
-                self.erc20._mint(recipient: address, :amount);
-
-                i += 1;
-            };
-            self.team_allocation.write(team_allocation);
-            self.pre_launch_holders_count.write(unique_count(initial_holders).try_into().unwrap());
-
-            team_allocation
-        }
 
         /// Ensures that the current call is not a part of a multicall.
         ///
@@ -434,52 +353,6 @@ mod UnruggableMemecoin {
             let tx_origin = tx_info.account_contract_address;
             assert(self.tx_hash_tracker.read(tx_origin) != tx_hash, 'Multi calls not allowed');
             self.tx_hash_tracker.write(tx_origin, tx_hash);
-        }
-
-
-        /// Enforces that the number of holders does not exceed the maximum allowed.
-        ///
-        /// When transfers are done between addresses that already
-        /// own tokens, we do not increment the number of holders.
-        /// It only gets incremented when the recipient holds no tokens.
-        /// If the sender will no longer hold tokens after the transfer, the
-        /// number of holders is decremented.
-        ///
-        /// # Arguments
-        ///
-        /// * `sender` - The sender of the tokens being transferred.
-        /// * `recipient` - The recipient of the tokens being transferred.
-        /// * `amount` - The amount of tokens being transferred.
-        ///
-        #[inline(always)]
-        fn enforce_prelaunch_holders_limit(
-            ref self: ContractState,
-            sender: ContractAddress,
-            recipient: ContractAddress,
-            amount: u256
-        ) {
-            if amount.is_zero() {
-                return;
-            }
-
-            // If this is not a mint and the sender will no longer hold tokens after the transfer,
-            // decrement the holders count.
-            if self.balanceOf(sender) == amount {
-                let current_holders_count = self.pre_launch_holders_count.read();
-
-                self.pre_launch_holders_count.write(current_holders_count - 1);
-            }
-
-            // If the recipient doesn't hold tokens yet - increment the holders count
-            if self.balanceOf(recipient).is_zero() {
-                let current_holders_count = self.pre_launch_holders_count.read();
-
-                assert(
-                    current_holders_count < MAX_HOLDERS_BEFORE_LAUNCH, errors::MAX_HOLDERS_REACHED
-                );
-
-                self.pre_launch_holders_count.write(current_holders_count + 1);
-            }
         }
     }
 }

--- a/contracts/src/utils.cairo
+++ b/contracts/src/utils.cairo
@@ -1,5 +1,5 @@
 mod math;
-use core::num::traits::{One};
+use core::num::traits::{Zero, One};
 use integer::u256_from_felt252;
 use starknet::ContractAddress;
 
@@ -40,6 +40,17 @@ fn unique_count<T, +Copy<T>, +Drop<T>, +PartialEq<T>>(mut self: Span<T>) -> u32 
         }
     };
     counter
+}
+
+fn sum<T, +Copy<T>, +Drop<T>, +PartialEq<T>, +Zero<T>, +AddEq<T>>(mut self: Span<T>) -> T {
+    let mut result = Zero::zero();
+    loop {
+        match self.pop_front() {
+            Option::Some(value) => { result += *value; },
+            Option::None => { break; }
+        }
+    };
+    result
 }
 
 fn contains<T, +Copy<T>, +Drop<T>, +PartialEq<T>>(mut self: Span<T>, value: T) -> bool {


### PR DESCRIPTION
# PR - Distribute tokens only after launch

PR to prevent malicious interactions with ekubo by creating pools without any counterparty and risking the supply to dry up.

## Memecoin
- Holders before launch is no longer a concept. The initial holders receive their tokens (for “free” ) once the coin is launched. As such, `pre_launch_holders_count` does not need to be tracked and enforcement of prelaunch holder count no longer makes sense.
- Allocation of team supply has moved from **memecoin.cairo** to **factory.cairo**
- All the initial tokens are minted to the factory
- The amount for the team allocation is written to the memecoin by the factory when finalising the launch.

## Factory
- Factorized the assertions upon launch to avoid code duplication.
- Introduced the calculation of the supply held by the team, capped to 10%, by iterating through each allocation of the initial holders.
- The `launch` functions now take as argument the `initial_holders` and `initial_holders_amount`. The MAX_HOLDERS_LAUNCH const is set to 10.
- The `launch` function calculate the total team allocation, and supply liquidity equal to the `total_supply - team_allocation`, and after launch distribute the team_allocation to the initial holders
- <!> IMPORTANT
- The Ekubo launch flow has been entirely reworked to avoid vulnerabilities. It now works as follows:
    - The owner of the memecoin will need to provide liquidity upon launch to cover for its initial allocation. For example, if it launches a coin at a price of 0.01ETH / MEME and the team is allocated 10% of the total supply, he needs to provide `quote_tokens = 0.1 * total_supply) * 0.01`.
    - The liquidity providing is done in two steps:
        - 1. Put the `team_allocation` in the LP, between bounds [initial_tick, initial_tick +1]
        - 2. Put the `lp_supply`(public liquidity) between bounds [initial_tick, +inf]
    - This ensures that the team can get its allocation from the pool at a price corresponding to the interval [starting_tick, starting_tick+1] 
    - Once the LP is provided, the funds sent to the factory are used to buy the initial holders tokens using an exact output swap. Considering the tick spacing and fees, it is recommended to send 1.02 *  quote_tokens to ensure that the swap passes - this needs to be tested more



# Utils
- fn sum() to sum the value of an array
- Ekubo util functions

# Tests to implement

Some of these tests are already partially implemented - and the way they are implemented is not necessarily 100% compatible with the current architecture (e.g. the reserve in quote tokens after a swap-in/swap-out is not 0 but not also contains the liquidity the team used to buy).

## Unit tests
- Fix failing unit tests. 
- Test the distribute_team_allocation function

## Ekubo

Test the launch flow for these scenarios.

- Memecoin is token0 in the pool, with a price MEME/ETH < 1
- Memecoin is token0 in the pool, with a price MEME/ETH > 1
- Memecoin is token1 in the pool, with a price MEME/ETH < 1
- Memecoin is token1 in the pool, with a price MEME/ETH > 1
- Test a launch with a pool with a 1% fee parameter
Each one of these tests will perform the following
- Launch the memecoin
- Assert that the reserve in quote tokens corresponds roughly (~ 0.5% uncertainty) to the amount sent by the team to buy tokens, which itself corresponds to the % of tokens to buy * the price to buy the tokens at. Example: The team allocates itself 10% of the total supply. The price is 0.01ETH/MEME. Thus, the team must send an amount of roughly 0.1 * total_supply * 0.01. Add an uncertainty of the size of the tick space and fee, because the execution will not happen at the launch price precisely. I observed that 1.2% should be enough So if `total_supply = 21M & price=0.01ETH/MEME`, send ~ `1.012*0.1*21M*0.01`
- Verify that the reserve in meme tokens is in the interval [0.99 * lp_tokens, 0.995 * lp_tokens] where lp_tokens is the total_supply of the coin - the amount allocated to the team
- Check that the LP position is tracked in the launcher
- Check that the initial holders have been allocated the correct amount of tokens.
- Check that events were emitted correctly
- Check that swaps work correctly
    - Can do a swap in / swap out
    - Withdraw fees
        - The amount collected of quote fees must be roughly pool_fee * amount_swapped 
        - The amount of collected memecoin fee must be 0
- Important: test that if someone initialises an Ekubo pool with the wrong initial_price, the person that launches can still add liauidity to the pool at the right price

