### PR TITLE
[contracts] save liquidity parameters at launch

### DIFF
--- a/contracts/src/exchanges/ekubo/ekubo_adapter.cairo
+++ b/contracts/src/exchanges/ekubo/ekubo_adapter.cairo
@@ -33,7 +33,7 @@ struct EkuboLaunchParameters {
     pool_params: EkuboPoolParameters
 }
 
-#[derive(Drop, Copy, Serde)]
+#[derive(Drop, Copy, starknet::Store, Serde)]
 struct EkuboPoolParameters {
     fee: u128,
     tick_spacing: u128,

--- a/contracts/src/exchanges/jediswap_adapter.cairo
+++ b/contracts/src/exchanges/jediswap_adapter.cairo
@@ -62,7 +62,7 @@ struct JediswapAdditionalParameters {
 }
 
 impl JediswapAdapterImpl of unruggable::exchanges::ExchangeAdapter<
-    JediswapAdditionalParameters, ContractAddress
+    JediswapAdditionalParameters, (ContractAddress, ContractAddress)
 > {
     fn create_and_add_liquidity(
         exchange_address: ContractAddress,
@@ -70,7 +70,7 @@ impl JediswapAdapterImpl of unruggable::exchanges::ExchangeAdapter<
         quote_address: ContractAddress,
         lp_supply: u256,
         additional_parameters: JediswapAdditionalParameters,
-    ) -> ContractAddress {
+    ) -> (ContractAddress, ContractAddress) {
         let JediswapAdditionalParameters{lock_manager_address, unlock_time, quote_amount, } =
             additional_parameters;
         let memecoin = IUnruggableMemecoinDispatcher { contract_address: token_address, };
@@ -110,7 +110,7 @@ impl JediswapAdapterImpl of unruggable::exchanges::ExchangeAdapter<
         // Lock LP tokens
         let lock_manager = ILockManagerDispatcher { contract_address: lock_manager_address };
         pair.approve(lock_manager_address, liquidity_received);
-        let locked_address = lock_manager
+        let lock_position = lock_manager
             .lock_tokens(
                 token: pair_address,
                 amount: liquidity_received,
@@ -118,6 +118,6 @@ impl JediswapAdapterImpl of unruggable::exchanges::ExchangeAdapter<
                 withdrawer: caller_address,
             );
 
-        pair.contract_address
+        (pair.contract_address, lock_position)
     }
 }

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -25,12 +25,15 @@ mod Factory {
         jediswap_adapter::JediswapAdditionalParameters, ekubo::launcher::EkuboLP
     };
     use unruggable::factory::{IFactory, LaunchParameters};
-    use unruggable::token::UnruggableMemecoin::LiquidityType;
     use unruggable::token::interface::{
         IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
     };
     use unruggable::utils::math::PercentageMath;
     use unruggable::utils::unique_count;
+    use unruggable::token::memecoin::{
+        UnruggableMemecoin::LiquidityType, UnruggableMemecoin::LiquidityParameters,
+        JediswapLiquidityParameters, EkuboLiquidityParameters
+    };
 
     /// The maximum percentage of the total supply that can be allocated to the team.
     /// This is to prevent the team from having too much control over the supply.
@@ -159,6 +162,9 @@ mod Factory {
             memecoin
                 .set_launched(
                     LiquidityType::JediERC20(pair_address),
+                    LiquidityParameters::Jediswap(
+                        JediswapLiquidityParameters { quote_address, quote_amount, }
+                    ),
                     :transfer_restriction_delay,
                     :max_percentage_buy_launch,
                     :team_allocation
@@ -206,6 +212,12 @@ mod Factory {
             memecoin
                 .set_launched(
                     LiquidityType::EkuboNFT(id),
+                    LiquidityType::EkuboNFT(id),
+                    LiquidityParameters::Ekubo(
+                        EkuboLiquidityParameters {
+                            quote_address, ekubo_pool_parameters: ekubo_parameters
+                        }
+                    ),
                     :transfer_restriction_delay,
                     :max_percentage_buy_launch,
                     :team_allocation

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -129,7 +129,7 @@ mod Factory {
             quote_amount: u256,
             unlock_time: u64,
         ) -> ContractAddress {
-            let (base_amount, team_allocation, pre_holders) = check_common_launch_parameters(
+            let (team_allocation, pre_holders) = check_common_launch_parameters(
                 @self, launch_parameters
             );
             let router_address = self.exchange_address(SupportedExchanges::Jediswap);
@@ -169,7 +169,6 @@ mod Factory {
                     :transfer_restriction_delay,
                     :max_percentage_buy_launch,
                     :team_allocation,
-                    :base_amount
                 );
 
             self
@@ -186,7 +185,7 @@ mod Factory {
             launch_parameters: LaunchParameters,
             ekubo_parameters: EkuboPoolParameters,
         ) -> (u64, EkuboLP) {
-            let (base_amount, team_allocation, pre_holders) = check_common_launch_parameters(
+            let (team_allocation, pre_holders) = check_common_launch_parameters(
                 @self, launch_parameters
             );
 
@@ -223,7 +222,6 @@ mod Factory {
                     :transfer_restriction_delay,
                     :max_percentage_buy_launch,
                     :team_allocation,
-                    :base_amount
                 );
             self
                 .emit(
@@ -306,7 +304,7 @@ mod Factory {
     ///
     fn check_common_launch_parameters(
         self: @ContractState, launch_parameters: LaunchParameters
-    ) -> (u256, u256, u8) {
+    ) -> (u256, u8) {
         let LaunchParameters{memecoin_address,
         transfer_restriction_delay,
         max_percentage_buy_launch,
@@ -324,11 +322,6 @@ mod Factory {
         assert(initial_holders.len() <= MAX_HOLDERS_LAUNCH.into(), errors::MAX_HOLDERS_REACHED);
 
         let initial_supply = memecoin.total_supply();
-
-        // Get base amount
-        let this = get_contract_address();
-        let memecoin = IUnruggableMemecoinDispatcher { contract_address: memecoin_address };
-        let base_amount = memecoin.balance_of(account: this);
 
         // Check that the sum of the amounts of initial holders does not exceed the max allocatable supply for a team.
         let max_team_allocation = initial_supply
@@ -348,7 +341,7 @@ mod Factory {
             i += 1;
         };
 
-        (base_amount, team_allocation, unique_count(initial_holders).try_into().unwrap())
+        (team_allocation, unique_count(initial_holders).try_into().unwrap())
     }
 
     fn distribute_team_alloc(

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -28,12 +28,12 @@ mod Factory {
     use unruggable::token::interface::{
         IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
     };
-    use unruggable::utils::math::PercentageMath;
-    use unruggable::utils::unique_count;
     use unruggable::token::memecoin::{
         UnruggableMemecoin::LiquidityType, UnruggableMemecoin::LiquidityParameters,
         JediswapLiquidityParameters, EkuboLiquidityParameters
     };
+    use unruggable::utils::math::PercentageMath;
+    use unruggable::utils::unique_count;
 
     /// The maximum percentage of the total supply that can be allocated to the team.
     /// This is to prevent the team from having too much control over the supply.
@@ -144,7 +144,8 @@ mod Factory {
                 launch_parameters;
 
             let memecoin = IUnruggableMemecoinDispatcher { contract_address: memecoin_address };
-            let (pair_address, lock_position) = jediswap_adapter::JediswapAdapterImpl::create_and_add_liquidity(
+            let (pair_address, lock_position) =
+                jediswap_adapter::JediswapAdapterImpl::create_and_add_liquidity(
                 exchange_address: router_address,
                 token_address: memecoin_address,
                 quote_address: quote_address,

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -144,7 +144,7 @@ mod Factory {
                 launch_parameters;
 
             let memecoin = IUnruggableMemecoinDispatcher { contract_address: memecoin_address };
-            let mut pair_address = jediswap_adapter::JediswapAdapterImpl::create_and_add_liquidity(
+            let (pair_address, lock_position) = jediswap_adapter::JediswapAdapterImpl::create_and_add_liquidity(
                 exchange_address: router_address,
                 token_address: memecoin_address,
                 quote_address: quote_address,
@@ -163,7 +163,7 @@ mod Factory {
                 .set_launched(
                     LiquidityType::JediERC20(pair_address),
                     LiquidityParameters::Jediswap(
-                        JediswapLiquidityParameters { quote_address, quote_amount, }
+                        (JediswapLiquidityParameters { quote_address, quote_amount }, lock_position)
                     ),
                     :transfer_restriction_delay,
                     :max_percentage_buy_launch,

--- a/contracts/src/tests/fork_tests/test_ekubo.cairo
+++ b/contracts/src/tests/fork_tests/test_ekubo.cairo
@@ -37,7 +37,7 @@ use unruggable::tests::unit_tests::utils::{
 use unruggable::token::interface::{
     IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
 };
-use unruggable::token::memecoin::LiquidityType;
+use unruggable::token::memecoin::{LiquidityType, LiquidityParameters};
 use unruggable::utils::math::PercentageMath;
 use unruggable::utils::sum;
 
@@ -261,6 +261,37 @@ fn test_launch_meme() {
             .bounds == Bounds { lower: starting_price, upper: i129 { sign: false, mag: 88719042 } },
         'wrong bounds '
     );
+
+    let liquidity_parameters = memecoin.launched_with_liquidity_parameters().unwrap();
+
+    match liquidity_parameters {
+        LiquidityParameters::Ekubo(ekubo_liquidity_parameters) => {
+            assert(ekubo_liquidity_parameters.quote_address == quote_address, 'Bad quote address');
+            assert(
+                ekubo_liquidity_parameters.ekubo_pool_parameters.fee == position.pool_key.fee,
+                'Bad ekubo fee'
+            );
+            assert(
+                ekubo_liquidity_parameters
+                    .ekubo_pool_parameters
+                    .tick_spacing == position
+                    .pool_key
+                    .tick_spacing,
+                'Bad ekubo tick spacing'
+            );
+            assert(
+                ekubo_liquidity_parameters.ekubo_pool_parameters.starting_tick == starting_tick,
+                'Bad ekubo starting tick'
+            );
+            assert(
+                ekubo_liquidity_parameters.ekubo_pool_parameters.bound == 88719042,
+                'Bad ekubo bound'
+            );
+        },
+        LiquidityParameters::Jediswap(jediswap_liquidity_parameters) => panic_with_felt252(
+            'wrong liquidity parameters type'
+        ),
+    }
 
     // Check events
     spy

--- a/contracts/src/tests/fork_tests/test_ekubo.cairo
+++ b/contracts/src/tests/fork_tests/test_ekubo.cairo
@@ -280,7 +280,7 @@ fn test_launch_meme() {
                 'Bad ekubo tick spacing'
             );
             assert(
-                ekubo_liquidity_parameters.ekubo_pool_parameters.starting_tick == starting_tick,
+                ekubo_liquidity_parameters.ekubo_pool_parameters.starting_price == starting_price,
                 'Bad ekubo starting tick'
             );
             assert(

--- a/contracts/src/tests/fork_tests/utils.cairo
+++ b/contracts/src/tests/fork_tests/utils.cairo
@@ -21,7 +21,6 @@ use unruggable::token::interface::{
     IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
 };
 
-
 fn EKUBO_LAUNCHER_ADDRESS() -> ContractAddress {
     'ekubo_launchpad'.try_into().unwrap()
 }
@@ -29,7 +28,6 @@ fn EKUBO_LAUNCHER_ADDRESS() -> ContractAddress {
 fn EKUBO_ROUTER_ADDRESS() -> ContractAddress {
     0x01b6f560def289b32e2a7b0920909615531a4d9d5636ca509045843559dc23d5.try_into().unwrap()
 }
-
 
 // quote token ensured to be token0
 

--- a/contracts/src/tests/unit_tests/test_factory.cairo
+++ b/contracts/src/tests/unit_tests/test_factory.cairo
@@ -248,30 +248,6 @@ fn test_launch_memecoin_with_ekubo_parameters() {
     stop_prank(CheatTarget::One(factory.contract_address));
 
     let liquidity_parameters = memecoin.launched_with_liquidity_parameters().unwrap();
-
-    match liquidity_parameters {
-        LiquidityParameters::Ekubo(ekubo_liquidity_parameters) => {
-            assert(
-                ekubo_liquidity_parameters.quote_address == eth.contract_address,
-                'Bad quote address'
-            );
-            assert(ekubo_liquidity_parameters.ekubo_pool_parameters.fee == fee, 'Bad ekubo fee');
-            assert(
-                ekubo_liquidity_parameters.ekubo_pool_parameters.tick_spacing == tick_spacing,
-                'Bad ekubo tick spacing'
-            );
-            assert(
-                ekubo_liquidity_parameters.ekubo_pool_parameters.starting_tick == starting_tick,
-                'Bad ekubo starting tick'
-            );
-            assert(
-                ekubo_liquidity_parameters.ekubo_pool_parameters.bound == bound, 'Bad ekubo bound'
-            );
-        },
-        LiquidityParameters::Jediswap(jediswap_liquidity_parameters) => panic_with_felt252(
-            'wrong liquidity parameters type'
-        ),
-    }
 }
 
 #[test]

--- a/contracts/src/tests/unit_tests/test_factory.cairo
+++ b/contracts/src/tests/unit_tests/test_factory.cairo
@@ -226,43 +226,6 @@ fn test_launch_memecoin_with_jediswap_parameters() {
 }
 
 #[test]
-fn test_launch_memecoin_with_ekubo_parameters() {
-    let owner = snforge_std::test_address();
-    let (memecoin, memecoin_address) = deploy_memecoin_through_factory_with_owner(owner);
-    let factory = IFactoryDispatcher { contract_address: MEMEFACTORY_ADDRESS() };
-    let eth = ERC20ABIDispatcher { contract_address: ETH_ADDRESS() };
-
-    let fee = 0xc49ba5e353f7d00000000000000000;
-    let tick_spacing = 5982;
-    let starting_price = i129 { sign: true, mag: 4600158 }; // 0.01ETH/MEME
-    let bound = 88719042;
-
-    // approve spending of eth by factory
-    let eth_amount: u256 = 1 * pow_256(10, 18); // 1 ETHER
-    let factory_balance_meme = memecoin.balanceOf(factory.contract_address);
-    start_prank(CheatTarget::One(eth.contract_address), owner);
-    eth.approve(factory.contract_address, eth_amount);
-    stop_prank(CheatTarget::One(eth.contract_address));
-
-    start_prank(CheatTarget::One(factory.contract_address), owner);
-    let pair_address = factory
-        .launch_on_ekubo(
-            LaunchParameters {
-                memecoin_address,
-                transfer_restriction_delay: TRANSFER_RESTRICTION_DELAY,
-                max_percentage_buy_launch: MAX_PERCENTAGE_BUY_LAUNCH,
-                quote_address: eth.contract_address,
-                initial_holders: INITIAL_HOLDERS(),
-                initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
-            },
-            EkuboPoolParameters { fee, tick_spacing, starting_price, bound, }
-        );
-    stop_prank(CheatTarget::One(factory.contract_address));
-
-    let liquidity_parameters = memecoin.launched_with_liquidity_parameters().unwrap();
-}
-
-#[test]
 fn test_launch_memecoin_pair_exists_should_succeed() {
     // Given
     let owner = snforge_std::test_address();

--- a/contracts/src/tests/unit_tests/test_factory.cairo
+++ b/contracts/src/tests/unit_tests/test_factory.cairo
@@ -2,7 +2,8 @@ use core::option::OptionTrait;
 use ekubo::types::i129::i129;
 use openzeppelin::token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
 use snforge_std::{
-    declare, ContractClassTrait, start_prank, stop_prank, CheatTarget, start_warp, stop_warp, start_roll, stop_roll
+    declare, ContractClassTrait, start_prank, stop_prank, CheatTarget, start_warp, stop_warp,
+    start_roll, stop_roll
 };
 use starknet::{ContractAddress, contract_address_const};
 use unruggable::exchanges::ekubo_adapter::EkuboPoolParameters;
@@ -207,7 +208,10 @@ fn test_launch_memecoin_with_jediswap_parameters() {
     match liquidity_parameters {
         LiquidityParameters::Ekubo(_) => panic_with_felt252('wrong liquidity parameters type'),
         LiquidityParameters::Jediswap(jediswap_liquidity_parameters) => {
-            assert(jediswap_liquidity_parameters.quote_address == eth.contract_address, 'Bad quote address');
+            assert(
+                jediswap_liquidity_parameters.quote_address == eth.contract_address,
+                'Bad quote address'
+            );
             assert(jediswap_liquidity_parameters.quote_amount == eth_amount, 'Bad quote amount');
         }
     }
@@ -239,12 +243,7 @@ fn test_launch_memecoin_with_ekubo_parameters() {
             TRANSFER_RESTRICTION_DELAY,
             MAX_PERCENTAGE_BUY_LAUNCH,
             eth.contract_address,
-            EkuboPoolParameters {
-                fee,
-                tick_spacing,
-                starting_tick,
-                bound
-            }
+            EkuboPoolParameters { fee, tick_spacing, starting_tick, bound }
         );
     stop_prank(CheatTarget::One(factory.contract_address));
 
@@ -252,13 +251,26 @@ fn test_launch_memecoin_with_ekubo_parameters() {
 
     match liquidity_parameters {
         LiquidityParameters::Ekubo(ekubo_liquidity_parameters) => {
-            assert(ekubo_liquidity_parameters.quote_address == eth.contract_address, 'Bad quote address');
+            assert(
+                ekubo_liquidity_parameters.quote_address == eth.contract_address,
+                'Bad quote address'
+            );
             assert(ekubo_liquidity_parameters.ekubo_pool_parameters.fee == fee, 'Bad ekubo fee');
-            assert(ekubo_liquidity_parameters.ekubo_pool_parameters.tick_spacing == tick_spacing, 'Bad ekubo tick spacing');
-            assert(ekubo_liquidity_parameters.ekubo_pool_parameters.starting_tick == starting_tick, 'Bad ekubo starting tick');
-            assert(ekubo_liquidity_parameters.ekubo_pool_parameters.bound == bound, 'Bad ekubo bound');
+            assert(
+                ekubo_liquidity_parameters.ekubo_pool_parameters.tick_spacing == tick_spacing,
+                'Bad ekubo tick spacing'
+            );
+            assert(
+                ekubo_liquidity_parameters.ekubo_pool_parameters.starting_tick == starting_tick,
+                'Bad ekubo starting tick'
+            );
+            assert(
+                ekubo_liquidity_parameters.ekubo_pool_parameters.bound == bound, 'Bad ekubo bound'
+            );
         },
-        LiquidityParameters::Jediswap(jediswap_liquidity_parameters) => panic_with_felt252('wrong liquidity parameters type'),
+        LiquidityParameters::Jediswap(jediswap_liquidity_parameters) => panic_with_felt252(
+            'wrong liquidity parameters type'
+        ),
     }
 }
 

--- a/contracts/src/tests/unit_tests/test_factory.cairo
+++ b/contracts/src/tests/unit_tests/test_factory.cairo
@@ -29,8 +29,8 @@ use unruggable::tests::unit_tests::utils::{
 use unruggable::token::interface::{
     IUnruggableMemecoin, IUnruggableMemecoinDispatcher, IUnruggableMemecoinDispatcherTrait
 };
-use unruggable::utils::sum;
 use unruggable::token::memecoin::{LiquidityType, LiquidityParameters};
+use unruggable::utils::sum;
 
 
 #[test]
@@ -255,9 +255,7 @@ fn test_launch_memecoin_with_ekubo_parameters() {
                 initial_holders: INITIAL_HOLDERS(),
                 initial_holders_amounts: INITIAL_HOLDERS_AMOUNTS(),
             },
-            EkuboPoolParameters {
-                fee, tick_spacing, starting_price, bound,
-            }
+            EkuboPoolParameters { fee, tick_spacing, starting_price, bound, }
         );
     stop_prank(CheatTarget::One(factory.contract_address));
 

--- a/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
+++ b/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
@@ -20,6 +20,7 @@ use unruggable::token::interface::{
 mod test_constructor {
     use UnruggableMemecoin::{
         transfer_restriction_delayContractMemberStateTrait, team_allocationContractMemberStateTrait,
+        pre_launch_holders_countContractMemberStateTrait,
         IUnruggableAdditional, IUnruggableMemecoinCamel, IUnruggableMemecoinSnake
     };
     use core::debug::PrintTrait;

--- a/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
+++ b/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
@@ -20,8 +20,7 @@ use unruggable::token::interface::{
 mod test_constructor {
     use UnruggableMemecoin::{
         transfer_restriction_delayContractMemberStateTrait, team_allocationContractMemberStateTrait,
-        pre_launch_holders_countContractMemberStateTrait, IUnruggableAdditional,
-        IUnruggableMemecoinCamel, IUnruggableMemecoinSnake
+        IUnruggableAdditional, IUnruggableMemecoinCamel, IUnruggableMemecoinSnake
     };
     use core::debug::PrintTrait;
     use core::traits::TryInto;

--- a/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
+++ b/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
@@ -104,6 +104,34 @@ mod memecoin_entrypoints {
     }
 
     #[test]
+    fn test_get_team_allocation_after_refund() {
+        let (memecoin, memecoin_address) = deploy_memecoin_through_factory();
+        let amount = 1_050_000 * pow_256(10, 18);
+
+        // refund half of the team allocation
+        start_prank(CheatTarget::One(memecoin.contract_address), INITIAL_HOLDER_1());
+        let send_amount = memecoin.transfer(memecoin.memecoin_factory_address(), amount);
+
+        let team_alloc = memecoin.get_team_allocation();
+        // Team alloc is set to 10% in test utils
+        assert(team_alloc == 1_050_000 * pow_256(10, 18), 'Invalid team allocation');
+    }
+
+    #[test]
+    fn test_get_team_allocation_after_post_launch_refund() {
+        let (memecoin, memecoin_address) = deploy_and_launch_memecoin();
+        let amount = 100 * pow_256(10, 18);
+
+        // refund half of the team allocation
+        start_prank(CheatTarget::One(memecoin.contract_address), INITIAL_HOLDER_1());
+        let send_amount = memecoin.transfer(memecoin.memecoin_factory_address(), amount);
+
+        let team_alloc = memecoin.get_team_allocation();
+        // Team alloc is set to 10% in test utils
+        assert(team_alloc == 2_100_000 * pow_256(10, 18), 'Invalid team allocation');
+    }
+
+    #[test]
     fn test_memecoin_factory_address() {
         let (memecoin, memecoin_address) = deploy_memecoin_through_factory();
 

--- a/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
+++ b/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
@@ -104,34 +104,6 @@ mod memecoin_entrypoints {
     }
 
     #[test]
-    fn test_get_team_allocation_after_refund() {
-        let (memecoin, memecoin_address) = deploy_memecoin_through_factory();
-        let amount = 1_050_000 * pow_256(10, 18);
-
-        // refund half of the team allocation
-        start_prank(CheatTarget::One(memecoin.contract_address), INITIAL_HOLDER_1());
-        let send_amount = memecoin.transfer(memecoin.memecoin_factory_address(), amount);
-
-        let team_alloc = memecoin.get_team_allocation();
-        // Team alloc is set to 10% in test utils
-        assert(team_alloc == 1_050_000 * pow_256(10, 18), 'Invalid team allocation');
-    }
-
-    #[test]
-    fn test_get_team_allocation_after_post_launch_refund() {
-        let (memecoin, memecoin_address) = deploy_and_launch_memecoin();
-        let amount = 100 * pow_256(10, 18);
-
-        // refund half of the team allocation
-        start_prank(CheatTarget::One(memecoin.contract_address), INITIAL_HOLDER_1());
-        let send_amount = memecoin.transfer(memecoin.memecoin_factory_address(), amount);
-
-        let team_alloc = memecoin.get_team_allocation();
-        // Team alloc is set to 10% in test utils
-        assert(team_alloc == 2_100_000 * pow_256(10, 18), 'Invalid team allocation');
-    }
-
-    #[test]
     fn test_memecoin_factory_address() {
         let (memecoin, memecoin_address) = deploy_memecoin_through_factory();
 

--- a/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
+++ b/contracts/src/tests/unit_tests/test_unruggable_memecoin.cairo
@@ -20,8 +20,8 @@ use unruggable::token::interface::{
 mod test_constructor {
     use UnruggableMemecoin::{
         transfer_restriction_delayContractMemberStateTrait, team_allocationContractMemberStateTrait,
-        pre_launch_holders_countContractMemberStateTrait,
-        IUnruggableAdditional, IUnruggableMemecoinCamel, IUnruggableMemecoinSnake
+        pre_launch_holders_countContractMemberStateTrait, IUnruggableAdditional,
+        IUnruggableMemecoinCamel, IUnruggableMemecoinSnake
     };
     use core::debug::PrintTrait;
     use core::traits::TryInto;

--- a/contracts/src/token/interface.cairo
+++ b/contracts/src/token/interface.cairo
@@ -60,7 +60,6 @@ trait IUnruggableMemecoin<TState> {
         transfer_restriction_delay: u64,
         max_percentage_buy_launch: u16,
         team_allocation: u256,
-        base_amount: u256
     );
 }
 
@@ -134,6 +133,5 @@ trait IUnruggableAdditional<TState> {
         transfer_restriction_delay: u64,
         max_percentage_buy_launch: u16,
         team_allocation: u256,
-        base_amount: u256
     );
 }

--- a/contracts/src/token/interface.cairo
+++ b/contracts/src/token/interface.cairo
@@ -1,6 +1,6 @@
 use openzeppelin::token::erc20::interface::{IERC20Metadata, IERC20, IERC20Camel};
 use starknet::ContractAddress;
-use super::memecoin::LiquidityType;
+use super::memecoin::{LiquidityType, LiquidityParameters};
 use unruggable::exchanges::SupportedExchanges;
 
 #[starknet::interface]
@@ -54,6 +54,7 @@ trait IUnruggableMemecoin<TState> {
     fn set_launched(
         ref self: TState,
         liquidity_type: LiquidityType,
+        liquidity_params: LiquidityParameters,
         transfer_restriction_delay: u64,
         max_percentage_buy_launch: u16,
         team_allocation: u256,
@@ -90,6 +91,13 @@ trait IUnruggableAdditional<TState> {
     /// * `bool` - True if the memecoin has been launched, false otherwise.
     fn is_launched(self: @TState) -> bool;
 
+    /// Returns the number of the block during which the token has been launched,
+    /// or 0 if not launched yet.
+    fn launched_at_block_number(self: @TState) -> u64;
+
+    /// Returns the liquidity parameters used to launch the memecoin.
+    fn launched_with_liquidity_parameters(self: @TState) -> LiquidityParameters;
+
     /// Returns the type of liquidity the memecoin was launched with,
     /// along with either the LP tokens addresses or the NFT ID.
     fn liquidity_type(self: @TState) -> Option<LiquidityType>;
@@ -119,6 +127,7 @@ trait IUnruggableAdditional<TState> {
     fn set_launched(
         ref self: TState,
         liquidity_type: LiquidityType,
+        liquidity_params: LiquidityParameters,
         transfer_restriction_delay: u64,
         max_percentage_buy_launch: u16,
         team_allocation: u256,

--- a/contracts/src/token/interface.cairo
+++ b/contracts/src/token/interface.cairo
@@ -60,6 +60,7 @@ trait IUnruggableMemecoin<TState> {
         transfer_restriction_delay: u64,
         max_percentage_buy_launch: u16,
         team_allocation: u256,
+        base_amount: u256
     );
 }
 
@@ -133,5 +134,6 @@ trait IUnruggableAdditional<TState> {
         transfer_restriction_delay: u64,
         max_percentage_buy_launch: u16,
         team_allocation: u256,
+        base_amount: u256
     );
 }

--- a/contracts/src/token/interface.cairo
+++ b/contracts/src/token/interface.cairo
@@ -48,6 +48,8 @@ trait IUnruggableMemecoin<TState> {
     /// # Returns
     ///     bool: whether token has launched
     fn is_launched(self: @TState) -> bool;
+    fn launched_at_block_number(self: @TState) -> u64;
+    fn launched_with_liquidity_parameters(self: @TState) -> Option<LiquidityParameters>;
     fn liquidity_type(self: @TState) -> Option<LiquidityType>;
     fn get_team_allocation(self: @TState) -> u256;
     fn memecoin_factory_address(self: @TState) -> ContractAddress;
@@ -96,7 +98,7 @@ trait IUnruggableAdditional<TState> {
     fn launched_at_block_number(self: @TState) -> u64;
 
     /// Returns the liquidity parameters used to launch the memecoin.
-    fn launched_with_liquidity_parameters(self: @TState) -> LiquidityParameters;
+    fn launched_with_liquidity_parameters(self: @TState) -> Option<LiquidityParameters>;
 
     /// Returns the type of liquidity the memecoin was launched with,
     /// along with either the LP tokens addresses or the NFT ID.

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -173,6 +173,7 @@ mod UnruggableMemecoin {
             transfer_restriction_delay: u64,
             max_percentage_buy_launch: u16,
             team_allocation: u256,
+            base_amount: u256
         ) {
             self.assert_only_factory();
             assert(!self.is_launched(), errors::ALREADY_LAUNCHED);
@@ -180,6 +181,8 @@ mod UnruggableMemecoin {
                 max_percentage_buy_launch >= MIN_MAX_PERCENTAGE_BUY_LAUNCH,
                 errors::MAX_PERCENTAGE_BUY_LAUNCH_TOO_LOW
             );
+
+            self.launch_liquidity_base_amount.write(Option::Some(base_amount));
 
             // save liquidity params and launch block number
             self

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -24,7 +24,7 @@ struct JediswapLiquidityParameters {
 #[derive(Copy, Drop, starknet::Store, Serde)]
 enum LiquidityParameters {
     Ekubo: EkuboLiquidityParameters,
-    Jediswap: JediswapLiquidityParameters,
+    Jediswap: (JediswapLiquidityParameters, ContractAddress),
 }
 
 #[starknet::contract]

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -44,8 +44,8 @@ mod UnruggableMemecoin {
         IERC20, IERC20Metadata, ERC20ABIDispatcher, ERC20ABIDispatcherTrait
     };
     use starknet::{
-        ContractAddress, contract_address_const, get_caller_address,
-        get_tx_info, get_block_timestamp, get_block_info
+        ContractAddress, contract_address_const, get_caller_address, get_tx_info,
+        get_block_timestamp, get_block_info
     };
     use super::{LiquidityType, LiquidityParameters};
 
@@ -153,8 +153,10 @@ mod UnruggableMemecoin {
             let total_supply = self.total_supply();
 
             match self.launch_liquidity_base_amount.read() {
-                Option::Some(launch_liquidity_base_amount) => total_supply - launch_liquidity_base_amount,
-                Option::None => total_supply - self.balance_of(account: self.factory_contract.read())
+                Option::Some(launch_liquidity_base_amount) => total_supply
+                    - launch_liquidity_base_amount,
+                Option::None => total_supply
+                    - self.balance_of(account: self.factory_contract.read())
             }
         }
 
@@ -185,9 +187,7 @@ mod UnruggableMemecoin {
             self.launch_liquidity_base_amount.write(Option::Some(base_amount));
 
             // save liquidity params and launch block number
-            self
-                .launch_block_number
-                .write(get_block_info().unbox().block_number);
+            self.launch_block_number.write(get_block_info().unbox().block_number);
             self.launch_liquidity_parameters.write(Option::Some(liquidity_params));
 
             self.liquidity_type.write(Option::Some(liquidity_type));

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -81,7 +81,6 @@ mod UnruggableMemecoin {
     struct Storage {
         marker_v_0: (),
         team_allocation: u256,
-        pre_launch_holders_count: u8,
         tx_hash_tracker: LegacyMap<ContractAddress, felt252>,
         transfer_restriction_delay: u64,
         launch_time: u64,
@@ -90,7 +89,6 @@ mod UnruggableMemecoin {
         factory_contract: ContractAddress,
         liquidity_type: Option<LiquidityType>,
         max_percentage_buy_launch: u16,
-        launch_liquidity_base_amount: Option<u256>,
         // Components.
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
@@ -168,7 +166,6 @@ mod UnruggableMemecoin {
             transfer_restriction_delay: u64,
             max_percentage_buy_launch: u16,
             team_allocation: u256,
-            base_amount: u256
         ) {
             self.assert_only_factory();
             assert(!self.is_launched(), errors::ALREADY_LAUNCHED);
@@ -176,8 +173,6 @@ mod UnruggableMemecoin {
                 max_percentage_buy_launch >= MIN_MAX_PERCENTAGE_BUY_LAUNCH,
                 errors::MAX_PERCENTAGE_BUY_LAUNCH_TOO_LOW
             );
-
-            self.launch_liquidity_base_amount.write(Option::Some(base_amount));
 
             // save liquidity params and launch block number
             self.launch_block_number.write(get_block_info().unbox().block_number);

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -150,14 +150,7 @@ mod UnruggableMemecoin {
 
         /// Returns the team allocation in tokens.
         fn get_team_allocation(self: @ContractState) -> u256 {
-            let total_supply = self.total_supply();
-
-            match self.launch_liquidity_base_amount.read() {
-                Option::Some(launch_liquidity_base_amount) => total_supply
-                    - launch_liquidity_base_amount,
-                Option::None => total_supply
-                    - self.balance_of(account: self.factory_contract.read())
-            }
+            self.team_allocation.read()
         }
 
         fn memecoin_factory_address(self: @ContractState) -> ContractAddress {

--- a/contracts/src/token/memecoin.cairo
+++ b/contracts/src/token/memecoin.cairo
@@ -1,6 +1,7 @@
 //! `UnruggableMemecoin` is an ERC20 token has additional features to prevent rug pulls.
 use starknet::ContractAddress;
 
+use unruggable::exchanges::ekubo_adapter::EkuboPoolParameters;
 
 #[derive(Copy, Drop, starknet::Store, Serde)]
 enum LiquidityType {
@@ -8,8 +9,27 @@ enum LiquidityType {
     EkuboNFT: u64
 }
 
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct EkuboLiquidityParameters {
+    ekubo_pool_parameters: EkuboPoolParameters,
+    quote_address: ContractAddress,
+}
+
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct JediswapLiquidityParameters {
+    quote_address: ContractAddress,
+    quote_amount: u256,
+}
+
+#[derive(Copy, Drop, starknet::Store, Serde)]
+enum LiquidityParameters {
+    Ekubo: EkuboLiquidityParameters,
+    Jediswap: JediswapLiquidityParameters,
+}
+
 #[starknet::contract]
 mod UnruggableMemecoin {
+    use core::box::BoxTrait;
     use core::traits::TryInto;
     use core::zeroable::Zeroable;
     use debug::PrintTrait;
@@ -25,9 +45,9 @@ mod UnruggableMemecoin {
     };
     use starknet::{
         ContractAddress, contract_address_const, get_contract_address, get_caller_address,
-        get_tx_info, get_block_timestamp
+        get_tx_info, get_block_timestamp, get_execution_info
     };
-    use super::LiquidityType;
+    use super::{LiquidityType, LiquidityParameters};
 
     use unruggable::errors;
     use unruggable::exchanges::jediswap_adapter::{
@@ -64,6 +84,8 @@ mod UnruggableMemecoin {
         tx_hash_tracker: LegacyMap<ContractAddress, felt252>,
         transfer_restriction_delay: u64,
         launch_time: u64,
+        launch_block_number: u64,
+        launch_liquidity_parameters: LiquidityParameters,
         factory_contract: ContractAddress,
         liquidity_type: Option<LiquidityType>,
         max_percentage_buy_launch: u16,
@@ -116,6 +138,14 @@ mod UnruggableMemecoin {
             self.launch_time.read().is_non_zero()
         }
 
+        fn launched_at_block_number(self: @ContractState) -> u64 {
+            self.launch_block_number.read()
+        }
+
+        fn launched_with_liquidity_parameters(self: @ContractState) -> LiquidityParameters {
+            self.launch_liquidity_parameters.read()
+        }
+
         /// Returns the team allocation in tokens.
         fn get_team_allocation(self: @ContractState) -> u256 {
             self.team_allocation.read()
@@ -132,6 +162,7 @@ mod UnruggableMemecoin {
         fn set_launched(
             ref self: ContractState,
             liquidity_type: LiquidityType,
+            liquidity_params: LiquidityParameters,
             transfer_restriction_delay: u64,
             max_percentage_buy_launch: u16,
             team_allocation: u256,
@@ -142,6 +173,12 @@ mod UnruggableMemecoin {
                 max_percentage_buy_launch >= MIN_MAX_PERCENTAGE_BUY_LAUNCH,
                 errors::MAX_PERCENTAGE_BUY_LAUNCH_TOO_LOW
             );
+
+            // save liquidity params and launch block number
+            self
+                .launch_block_number
+                .write(get_execution_info().unbox().block_info.unbox().block_number);
+            self.launch_liquidity_parameters.write(liquidity_params);
 
             self.liquidity_type.write(Option::Some(liquidity_type));
             self.launch_time.write(get_block_timestamp());


### PR DESCRIPTION
- Store liquidity parameters and block number at launch to allow FE to retrieve the mcap at launch without the need of an indexer. Useful feature to flag tokens launched with a very low mcap as potentially ruggable, or with an unknown quote token.
- Save lock position address at jediswap launch, to allow FE to retrieve the liquidity locking status without the need of an indexer.