### PR TITLE
[contracts] migrate locker manager on factory constructor

### DIFF
--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -75,6 +75,7 @@ mod Factory {
         exchange_configs: LegacyMap<SupportedExchanges, ContractAddress>,
         deployed_memecoins: LegacyMap<ContractAddress, bool>,
         lock_manager_address: ContractAddress,
+        migrated_lock_managers: LegacyMap<ContractAddress, ContractAddress>,
     }
 
     #[constructor]
@@ -83,7 +84,7 @@ mod Factory {
         memecoin_class_hash: ClassHash,
         lock_manager_address: ContractAddress,
         mut exchanges: Span<(SupportedExchanges, ContractAddress)>,
-        mut migrated_tokens: Span<ContractAddress>,
+        mut migrated_tokens: Span<(ContractAddress, ContractAddress)>,
     ) {
         self.memecoin_class_hash.write(memecoin_class_hash);
         self.lock_manager_address.write(lock_manager_address);
@@ -101,7 +102,12 @@ mod Factory {
         // Migrate old tokens, mark them as deployed
         loop {
             match migrated_tokens.pop_front() {
-                Option::Some(address) => self.deployed_memecoins.write(*address, true),
+                Option::Some((
+                    address, lock_manager
+                )) => {
+                    self.deployed_memecoins.write(*address, true);
+                    self.migrated_lock_managers.write(*address, *lock_manager);
+                },
                 Option::None => { break; }
             }
         };
@@ -314,18 +320,24 @@ mod Factory {
                 Option::Some(liquidity_type) => liquidity_type,
                 Option::None => { return Option::None; },
             };
-            let locker_address = match liquidity_type {
-                LiquidityType::JediERC20(pair_address) => {
-                    // ERC20 tokens are locked inside an ERC20Tokens-Locker
-                    self.lock_manager_address.read()
-                },
-                LiquidityType::StarkDeFiERC20(pair_address) => {
-                    // same as above
-                    self.lock_manager_address.read()
-                },
-                LiquidityType::EkuboNFT(id) => {
-                    // Ekubo NFTs are locked inside the EkuboLauncher contract
-                    self.exchange_address(SupportedExchanges::Ekubo)
+
+            let migrated_locker_address = self.migrated_lock_managers.read(token);
+            let locker_address = if (migrated_locker_address.is_non_zero()) {
+                migrated_locker_address
+            } else {
+                match liquidity_type {
+                    LiquidityType::JediERC20(pair_address) => {
+                        // ERC20 tokens are locked inside an ERC20Tokens-Locker
+                        self.lock_manager_address.read()
+                    },
+                    LiquidityType::StarkDeFiERC20(pair_address) => {
+                        // same as above
+                        self.lock_manager_address.read()
+                    },
+                    LiquidityType::EkuboNFT(id) => {
+                        // Ekubo NFTs are locked inside the EkuboLauncher contract
+                        self.exchange_address(SupportedExchanges::Ekubo)
+                    }
                 }
             };
 

--- a/contracts/src/factory/factory.cairo
+++ b/contracts/src/factory/factory.cairo
@@ -348,6 +348,10 @@ mod Factory {
             self.exchange_configs.read(exchange)
         }
 
+        fn lock_manager_address(self: @ContractState) -> ContractAddress {
+            self.lock_manager_address.read()
+        }
+
         fn is_memecoin(self: @ContractState, address: ContractAddress) -> bool {
             self.deployed_memecoins.read(address)
         }

--- a/contracts/src/factory/interface.cairo
+++ b/contracts/src/factory/interface.cairo
@@ -115,11 +115,11 @@ trait IFactory<TContractState> {
     /// same as launch_on_jediswap
     ///
     /// # Returns
-    /// same as launch_on_jediswap  
-    /// 
+    /// same as launch_on_jediswap
+    ///
     /// # Panics
     ///
-    /// same as launch_on_jediswap   
+    /// same as launch_on_jediswap
     ///
     fn launch_on_starkdefi(
         ref self: TContractState,
@@ -139,6 +139,9 @@ trait IFactory<TContractState> {
     ///
     /// * `ContractAddress` - The contract address associated with the given Exchange name.
     fn exchange_address(self: @TContractState, exchange: SupportedExchanges) -> ContractAddress;
+
+    /// Returns the address of the Lock manager, provided at factory deployment.
+    fn lock_manager_address(self: @TContractState) -> ContractAddress;
 
     /// Returns information about the locked liquidity of a token launched with unruggable.
     ///

--- a/contracts/src/tests/unit_tests/test_factory.cairo
+++ b/contracts/src/tests/unit_tests/test_factory.cairo
@@ -146,13 +146,17 @@ fn test_migrate_memecoin_from_old_factory() {
             eth_amount,
             DEFAULT_MIN_LOCKTIME,
         );
+    let (memecoin_lock_manager, _) = factory.locked_liquidity(memecoin_address).unwrap();
     stop_prank(CheatTarget::One(factory.contract_address));
 
     // New factory
     let factory_hash = ContractClass { class_hash: get_class_hash(factory.contract_address) };
     let memecoin_hash = get_class_hash(memecoin_address);
     let mut calldata = array![];
-    let migrated_tokens: Span<ContractAddress> = array![memecoin_address].span();
+    let migrated_tokens: Span<(ContractAddress, ContractAddress)> = array![
+        (memecoin_address, memecoin_lock_manager)
+    ]
+        .span();
     let mut amms: Array<(SupportedExchanges, ContractAddress)> = array![];
     Serde::serialize(@memecoin_hash, ref calldata);
     Serde::serialize(@0, ref calldata);

--- a/contracts/src/tests/unit_tests/test_factory.cairo
+++ b/contracts/src/tests/unit_tests/test_factory.cairo
@@ -166,7 +166,16 @@ fn test_migrate_memecoin_from_old_factory() {
         .deploy_at(@calldata, 'new_factory'.try_into().unwrap())
         .expect('UnrugFactory deployment failed');
     let new_factory_dispatcher = IFactoryDispatcher { contract_address: new_factory };
+
+    let new_locker_manager = new_factory_dispatcher.lock_manager_address();
+
+    let old_memecoin_lock_manager = memecoin_lock_manager;
+    let (new_memecoin_lock_manager, _) = factory.locked_liquidity(memecoin_address).unwrap();
+
     assert!(new_factory_dispatcher.is_memecoin(memecoin_address), "should be migrated");
+
+    assert!(new_locker_manager != old_memecoin_lock_manager, "lockers should be different");
+    assert!(new_memecoin_lock_manager == old_memecoin_lock_manager, "locker should be migrated");
 }
 
 #[test]


### PR DESCRIPTION
In factory constructor, implement a way to also migrate memecoin's locker manager