### PR TITLE
feat: Sign Transaction page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import AppLayout from './components/Layout/App'
 import HomeLayout from './components/Layout/Home'
 import DeployPage from './pages/Deploy'
 import HomePage from './pages/Home'
+import SignTransaction from './pages/SignTransaction/SignTransaction'
 import TokenPage from './pages/Token'
 import TokensPage from './pages/Tokens'
 import WalletRedirect from './pages/WalletRedirect'
@@ -44,6 +45,14 @@ const router = createBrowserRouter([
   {
     path: '/wallet-redirect/:redirectUrl',
     element: <WalletRedirect />,
+  },
+  {
+    path: '/sign-transaction/:calls',
+    element: (
+      <AppLayout>
+        <SignTransaction />
+      </AppLayout>
+    ),
   },
 ])
 

--- a/frontend/src/pages/SignTransaction/SignTransaction.tsx
+++ b/frontend/src/pages/SignTransaction/SignTransaction.tsx
@@ -1,0 +1,77 @@
+import { useAccount } from '@starknet-react/core'
+import { useEffect, useMemo } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { PrimaryButton } from 'src/components/Button'
+import Section from 'src/components/Section'
+import { useWalletConnectModal } from 'src/hooks/useModal'
+import { useExecuteTransaction } from 'src/hooks/useTransactions'
+import Box from 'src/theme/components/Box'
+import { Column } from 'src/theme/components/Flex'
+import * as Text from 'src/theme/components/Text'
+import type { Call } from 'starknet'
+
+import * as styles from './style.css'
+
+export default function SignTransaction() {
+  const { calls } = useParams()
+
+  const decodedCalls = useMemo(() => {
+    const encodedCalls = decodeURIComponent(calls ?? '')
+    let decodedCalls: Call[] = []
+
+    try {
+      decodedCalls = JSON.parse(encodedCalls)
+      if (!Array.isArray(decodedCalls)) decodedCalls = []
+    } catch (error) {
+      //
+    }
+
+    return decodedCalls
+  }, [calls])
+
+  const [walletConnectModalShown, toggleWalletConnectModal] = useWalletConnectModal()
+  const executeTransaction = useExecuteTransaction()
+  const navigate = useNavigate()
+
+  const { address } = useAccount()
+
+  useEffect(() => {
+    if (!address && !walletConnectModalShown) {
+      toggleWalletConnectModal()
+    }
+  }, [address, walletConnectModalShown, toggleWalletConnectModal])
+
+  const onSignClick = async () => {
+    if (!address || !decodedCalls?.length) return
+
+    executeTransaction({
+      calls: decodedCalls,
+      action: 'Sign Transaction',
+      onSuccess: () => {
+        navigate('/')
+      },
+    })
+  }
+
+  return (
+    <Section>
+      <Box className={styles.container}>
+        <Column gap="24">
+          <Text.HeadlineLarge>Sign Transaction</Text.HeadlineLarge>
+
+          <Text.Body>
+            You are about to sign {decodedCalls.length} calls. Please make sure to review them carefully before signing.
+          </Text.Body>
+
+          <Text.Body>
+            <b>If you did not initiate this request, please do not sign.</b>
+          </Text.Body>
+
+          <PrimaryButton type="submit" large onClick={onSignClick}>
+            Sign Transaction
+          </PrimaryButton>
+        </Column>
+      </Box>
+    </Section>
+  )
+}

--- a/frontend/src/pages/SignTransaction/style.css.ts
+++ b/frontend/src/pages/SignTransaction/style.css.ts
@@ -1,0 +1,16 @@
+import { style } from '@vanilla-extract/css'
+import { sprinkles, vars } from 'src/theme/css/sprinkles.css'
+
+export const container = style([
+  {
+    padding: '16px 12px 12px',
+    boxShadow: `0 0 16px ${vars.color.bg1}`,
+  },
+  sprinkles({
+    maxWidth: '480',
+    width: 'full',
+    background: 'bg1',
+    borderRadius: '10',
+    border: 'light',
+  }),
+])


### PR DESCRIPTION
This page is intended to be used with the Telegram bot. If the user is in desktop, user can choose the option to sign the transaction with the desktop web browser. User then redirected to this page to sign the transaction and deploy or launch the token.

![resim](https://github.com/keep-starknet-strange/unruggable.meme/assets/86152092/2a26180b-9d90-4de6-b5a4-89f78edaa36d)


Related
- https://github.com/keep-starknet-strange/unrug-tg-bot/pull/3