### PR TITLE
Fix: Click outside of dropdown to close the dropdown

### DIFF
--- a/packages/frontend/src/components/Dropdown/index.tsx
+++ b/packages/frontend/src/components/Dropdown/index.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import Box from 'src/theme/components/Box'
+import { Column } from 'src/theme/components/Flex'
+import * as Icons from 'src/theme/components/Icons'
 
-export function useDropdown() {
+import { IconButton } from '../Button'
+import * as styles from './style.css'
+
+const Dropdown = ({ children }: any) => {
   const dropdownRef = useRef<HTMLDivElement>(null)
   const [dropdownOpened, setDropdownOpened] = useState(false)
   const toggleDropdown = useCallback(() => setDropdownOpened((state) => !state), [])
@@ -21,5 +27,14 @@ export function useDropdown() {
     return
   }, [dropdownRef, dropdownOpened])
 
-  return { dropdownRef, dropdownOpened, toggleDropdown }
+  return (
+    <Box position="relative" ref={dropdownRef}>
+      <IconButton onClick={toggleDropdown} large>
+        <Icons.ThreeDots display="block" width="16" />
+      </IconButton>
+      {dropdownOpened && <Column className={styles.dropdown()}>{children}</Column>}
+    </Box>
+  )
 }
+
+export default Dropdown

--- a/packages/frontend/src/components/Dropdown/index.tsx
+++ b/packages/frontend/src/components/Dropdown/index.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
+import { useOnClickOutside } from 'src/hooks/useClickOutside'
 import Box from 'src/theme/components/Box'
 import { Column } from 'src/theme/components/Flex'
 import * as Icons from 'src/theme/components/Icons'
@@ -6,33 +7,22 @@ import * as Icons from 'src/theme/components/Icons'
 import { IconButton } from '../Button'
 import * as styles from './style.css'
 
-const Dropdown = ({ children }: any) => {
+const Dropdown = ({ children }: React.PropsWithChildren) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  // dropdown state
+  const toggleDropdown = useCallback(() => setIsOpen((state) => !state), [])
   const dropdownRef = useRef<HTMLDivElement>(null)
-  const [dropdownOpened, setDropdownOpened] = useState(false)
-  const toggleDropdown = useCallback(() => setDropdownOpened((state) => !state), [])
 
-  const handleClickOutside = (e: MouseEvent) => {
-    if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-      setDropdownOpened(false)
-    }
-  }
-
-  useEffect(() => {
-    if (dropdownOpened) {
-      document.addEventListener('mousedown', handleClickOutside)
-      return () => {
-        document.removeEventListener('mousedown', handleClickOutside)
-      }
-    }
-    return
-  }, [dropdownRef, dropdownOpened])
+  useOnClickOutside(dropdownRef, isOpen ? toggleDropdown : undefined)
 
   return (
     <Box position="relative" ref={dropdownRef}>
       <IconButton onClick={toggleDropdown} large>
         <Icons.ThreeDots display="block" width="16" />
       </IconButton>
-      {dropdownOpened && <Column className={styles.dropdown()}>{children}</Column>}
+
+      {isOpen && <Column className={styles.dropdown()}>{children}</Column>}
     </Box>
   )
 }

--- a/packages/frontend/src/components/Dropdown/style.css.ts
+++ b/packages/frontend/src/components/Dropdown/style.css.ts
@@ -1,0 +1,19 @@
+import { recipe } from '@vanilla-extract/recipes'
+import { sprinkles, vars } from 'src/theme/css/sprinkles.css'
+
+export const dropdown = recipe({
+  base: [
+    {
+      boxShadow: `0 0 8px ${vars.color.bg1}`,
+    },
+    sprinkles({
+      position: 'absolute',
+      background: 'bg2',
+      right: '0',
+      marginTop: '8',
+      borderRadius: '10',
+      overflow: 'hidden',
+      minWidth: '180',
+    }),
+  ],
+})

--- a/packages/frontend/src/components/Input/index.tsx
+++ b/packages/frontend/src/components/Input/index.tsx
@@ -5,7 +5,7 @@ import Box, { BoxProps } from 'src/theme/components/Box'
 import * as styles from './style.css'
 
 interface InputProps extends BoxProps {
-  addon?: React.ReactNode
+  addon?: React.PropsWithChildren['children']
 }
 
 const Input = forwardRef<HTMLElement, InputProps>(function ({ addon, className, ...props }, ref) {
@@ -23,7 +23,7 @@ export default Input
 // Formattable Input
 
 export interface FormattableInputProps extends BoxProps {
-  addon?: React.ReactNode
+  addon?: React.PropsWithChildren['children']
   formatInput: (value: string) => string | undefined
 }
 

--- a/packages/frontend/src/components/Layout/App/index.tsx
+++ b/packages/frontend/src/components/Layout/App/index.tsx
@@ -8,11 +8,7 @@ import { constants } from 'starknet'
 
 import * as styles from './style.css'
 
-interface AppLayoutProps {
-  children: React.ReactNode
-}
-
-export default function AppLayout({ children }: AppLayoutProps) {
+export default function AppLayout({ children }: React.PropsWithChildren) {
   const { chain } = useNetwork()
   const chaindId = useChainId()
 

--- a/packages/frontend/src/components/Layout/Home.tsx
+++ b/packages/frontend/src/components/Layout/Home.tsx
@@ -1,10 +1,6 @@
 import NavBar from '../NavBar'
 
-interface HomeLayoutProps {
-  children: React.ReactNode
-}
-
-export default function HomeLayout({ children }: HomeLayoutProps) {
+export default function HomeLayout({ children }: React.PropsWithChildren) {
   return (
     <>
       <NavBar />

--- a/packages/frontend/src/components/Modal/Content.tsx
+++ b/packages/frontend/src/components/Modal/Content.tsx
@@ -6,12 +6,11 @@ import * as Text from 'src/theme/components/Text'
 import * as styles from './Content.css'
 
 interface ContentProps {
-  children: React.ReactNode
   title: string
   close: () => void
 }
 
-export default function Content({ children, title, close }: ContentProps) {
+export default function Content({ children, title, close }: React.PropsWithChildren<ContentProps>) {
   return (
     <Box className={styles.content}>
       <Column gap="42">

--- a/packages/frontend/src/components/Slider/index.tsx
+++ b/packages/frontend/src/components/Slider/index.tsx
@@ -25,7 +25,7 @@ interface SliderProps {
   max: number
   loading?: boolean
   onSlidingChange: (value: number) => void
-  addon?: React.ReactNode
+  addon?: React.PropsWithChildren['children']
 }
 
 export default function Slider({ value, min = 0, step = 1, max, addon, onSlidingChange }: SliderProps) {

--- a/packages/frontend/src/components/Web3Provider/index.tsx
+++ b/packages/frontend/src/components/Web3Provider/index.tsx
@@ -5,11 +5,7 @@ import { WebWalletConnector } from 'starknetkit/webwallet'
 
 // STARKNET
 
-interface StarknetProviderProps {
-  children: React.ReactNode
-}
-
-export function StarknetProvider({ children }: StarknetProviderProps) {
+export function StarknetProvider({ children }: React.PropsWithChildren) {
   const { connectors: injected } = useInjectedConnectors({
     recommended: [argent(), braavos()],
     includeRecommended: 'always',

--- a/packages/frontend/src/components/common/Portal/index.tsx
+++ b/packages/frontend/src/components/common/Portal/index.tsx
@@ -1,9 +1,5 @@
 import { createPortal } from 'react-dom'
 
-interface PortalProps {
-  children: React.ReactNode
-}
-
-export default function Portal({ children }: PortalProps) {
+export default function Portal({ children }: React.PropsWithChildren) {
   return createPortal(children, document.body)
 }

--- a/packages/frontend/src/hooks/useClickOutside.ts
+++ b/packages/frontend/src/hooks/useClickOutside.ts
@@ -1,0 +1,37 @@
+// https://github.com/Uniswap/interface/blob/9209ca438a9a0402901468249f6598b1fee0c062/apps/web/src/hooks/useOnClickOutside.ts
+
+import { RefObject, useEffect, useRef } from 'react'
+
+export function useOnClickOutside<T extends HTMLElement>(
+  node: RefObject<T | undefined>,
+  handler: undefined | (() => void),
+  ignoredNodes: Array<RefObject<T | undefined>> = []
+) {
+  const handlerRef = useRef<undefined | (() => void)>(handler)
+
+  useEffect(() => {
+    handlerRef.current = handler
+  }, [handler])
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      const nodeClicked = node.current?.contains(e.target as Node)
+      const ignoredNodeClicked = ignoredNodes.reduce(
+        (reducer, val) => reducer || !!val.current?.contains(e.target as Node),
+        false
+      )
+
+      if ((nodeClicked || ignoredNodeClicked) ?? false) {
+        return
+      }
+
+      if (handlerRef.current) handlerRef.current()
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [node, ignoredNodes])
+}

--- a/packages/frontend/src/hooks/useDropdown.ts
+++ b/packages/frontend/src/hooks/useDropdown.ts
@@ -1,0 +1,25 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export function useDropdown() {
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const [dropdownOpened, setDropdownOpened] = useState(false)
+  const toggleDropdown = useCallback(() => setDropdownOpened((state) => !state), [])
+
+  const handleClickOutside = (e: MouseEvent) => {
+    if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+      setDropdownOpened(false)
+    }
+  }
+
+  useEffect(() => {
+    if (dropdownOpened) {
+      document.addEventListener('mousedown', handleClickOutside)
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside)
+      }
+    }
+    return
+  }, [dropdownRef, dropdownOpened])
+
+  return { dropdownRef, dropdownOpened, toggleDropdown }
+}

--- a/packages/frontend/src/pages/Token/Metrics.tsx
+++ b/packages/frontend/src/pages/Token/Metrics.tsx
@@ -2,19 +2,17 @@ import { Fraction, Percent } from '@uniswap/sdk-core'
 import moment from 'moment'
 import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
-import { IconButton } from 'src/components/Button'
+import Dropdown from 'src/components/Dropdown'
 import { DECIMALS, FOREVER, LiquidityType } from 'src/constants/misc'
 import { Safety, SAFETY_COLORS } from 'src/constants/safety'
 import { QUOTE_TOKENS } from 'src/constants/tokens'
 import useChainId from 'src/hooks/useChainId'
-import { useDropdown } from 'src/hooks/useDropdown'
 import useLinks from 'src/hooks/useLinks'
 import useMemecoin from 'src/hooks/useMemecoin'
 import { useQuoteTokenPrice } from 'src/hooks/usePrice'
 import useQuoteToken from 'src/hooks/useQuote'
 import Box from 'src/theme/components/Box'
 import { Column, Row } from 'src/theme/components/Flex'
-import * as Icons from 'src/theme/components/Icons'
 import * as Text from 'src/theme/components/Text'
 import { formatPercentage } from 'src/utils/amount'
 import { decimalsScale } from 'src/utils/decimalScale'
@@ -30,12 +28,8 @@ import {
 import * as styles from './style.css'
 
 export default function TokenMetrics() {
-
   // memecoin
   const { data: memecoin } = useMemecoin()
-
-  // dropdown
-  const { dropdownRef, dropdownOpened, toggleDropdown } = useDropdown()
 
   // dropdown links
   const links = useLinks(memecoin?.address)
@@ -143,29 +137,23 @@ export default function TokenMetrics() {
           <Text.HeadlineSmall color="text2">${memecoin.symbol}</Text.HeadlineSmall>
         </Row>
 
-        <Box position="relative" ref={dropdownRef}>
-          <IconButton onClick={toggleDropdown} large>
-            <Icons.ThreeDots display="block" width="16" />
-          </IconButton>
+        <Dropdown>
+          {(Object.keys(links) as Array<keyof typeof links>).map((name) => {
+            const link = links[name]
 
-          <Column className={styles.dropdown({ opened: dropdownOpened })}>
-            {(Object.keys(links) as Array<keyof typeof links>).map((name) => {
-              const link = links[name]
+            if (link) {
+              return (
+                <Link target="_blank" to={link} key={name}>
+                  <Box className={styles.dropdownRow}>
+                    <Text.Body style={{ textTransform: 'capitalize' }}>{name}</Text.Body>
+                  </Box>
+                </Link>
+              )
+            }
 
-              if (link) {
-                return (
-                  <Link target="_blank" to={link} key={name}>
-                    <Box className={styles.dropdownRow}>
-                      <Text.Body style={{ textTransform: 'capitalize' }}>{name}</Text.Body>
-                    </Box>
-                  </Link>
-                )
-              }
-
-              return <></>
-            })}
-          </Column>
-        </Box>
+            return <></>
+          })}
+        </Dropdown>
       </Row>
 
       <Box className={styles.hr} />

--- a/packages/frontend/src/pages/Token/Metrics.tsx
+++ b/packages/frontend/src/pages/Token/Metrics.tsx
@@ -1,12 +1,13 @@
 import { Fraction, Percent } from '@uniswap/sdk-core'
 import moment from 'moment'
-import { useCallback, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { IconButton } from 'src/components/Button'
 import { DECIMALS, FOREVER, LiquidityType } from 'src/constants/misc'
 import { Safety, SAFETY_COLORS } from 'src/constants/safety'
 import { QUOTE_TOKENS } from 'src/constants/tokens'
 import useChainId from 'src/hooks/useChainId'
+import { useDropdown } from 'src/hooks/useDropdown'
 import useLinks from 'src/hooks/useLinks'
 import useMemecoin from 'src/hooks/useMemecoin'
 import { useQuoteTokenPrice } from 'src/hooks/usePrice'
@@ -30,13 +31,12 @@ import * as styles from './style.css'
 
 export default function TokenMetrics() {
   // TODO: create a dropdown component
-  const [dropdownOpened, setDropdownOpened] = useState(false)
 
   // memecoin
   const { data: memecoin } = useMemecoin()
 
   // dropdown
-  const toggleDropdown = useCallback(() => setDropdownOpened((state) => !state), [])
+  const { dropdownRef, dropdownOpened, toggleDropdown } = useDropdown()
 
   // dropdown links
   const links = useLinks(memecoin?.address)
@@ -144,7 +144,7 @@ export default function TokenMetrics() {
           <Text.HeadlineSmall color="text2">${memecoin.symbol}</Text.HeadlineSmall>
         </Row>
 
-        <Box position="relative">
+        <Box position="relative" ref={dropdownRef}>
           <IconButton onClick={toggleDropdown} large>
             <Icons.ThreeDots display="block" width="16" />
           </IconButton>

--- a/packages/frontend/src/pages/Token/Metrics.tsx
+++ b/packages/frontend/src/pages/Token/Metrics.tsx
@@ -30,7 +30,6 @@ import {
 import * as styles from './style.css'
 
 export default function TokenMetrics() {
-  // TODO: create a dropdown component
 
   // memecoin
   const { data: memecoin } = useMemecoin()

--- a/packages/frontend/src/pages/Token/style.css.ts
+++ b/packages/frontend/src/pages/Token/style.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css'
-import { recipe } from '@vanilla-extract/recipes'
 import { sprinkles, vars } from 'src/theme/css/sprinkles.css'
 
 export const container = style([
@@ -47,35 +46,6 @@ export const errorContainer = sprinkles({
   paddingX: '8',
   paddingTop: '4',
   color: 'error',
-})
-
-export const dropdown = recipe({
-  base: [
-    {
-      boxShadow: `0 0 8px ${vars.color.bg1}`,
-    },
-    sprinkles({
-      position: 'absolute',
-      background: 'bg2',
-      right: '0',
-      marginTop: '8',
-      borderRadius: '10',
-      overflow: 'hidden',
-      minWidth: '180',
-    }),
-  ],
-
-  variants: {
-    opened: {
-      false: {
-        display: 'none',
-      },
-    },
-  },
-
-  defaultVariants: {
-    opened: false,
-  },
 })
 
 export const dropdownRow = style([


### PR DESCRIPTION
Resolves issue: https://github.com/keep-starknet-strange/unruggable.meme/issues/230

Fix video:

https://github.com/keep-starknet-strange/unruggable.meme/assets/45929094/591ad05f-6b15-4ed8-bb48-7c95df0f70f5

Dev test plan:
- Run app locally.
- Now, go http://localhost:3000/token/0x06e2c03e31f6cda18484ed035c02a25d6075393e11da24c898337f736716acae
- Click on dropdown button (button with 3 dots).
- Make sure that dropdown opens.
- Now, click outside of dropdown and verify that dropdown closes as expected.
- Edge case: Click on dropdown button and verify that dropdown closes as expected rather than re-opening.


