### PR TITLE
ci: Fix contracts directory path

### DIFF
--- a/.github/workflows/contracts_build.yml
+++ b/.github/workflows/contracts_build.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: software-mansion/setup-scarb@v1
       - name: Check cairo format
         run: scarb fmt --check
-        working-directory: contracts
+        working-directory: packages/contracts
       - name: Build cairo programs
         run: scarb build
-        working-directory: contracts
+        working-directory: packages/contracts

--- a/.github/workflows/contracts_test.yml
+++ b/.github/workflows/contracts_test.yml
@@ -14,4 +14,4 @@ jobs:
           starknet-foundry-version: 0.14.0
       - name: Run cairo tests
         run: snforge test unit_tests
-        working-directory: contracts
+        working-directory: packages/contracts


### PR DESCRIPTION
Fixes the wrong working directory path in github action files. These paths changed when the repo was converted into a monorepo in PR #223