### PR TITLE
fix: Backend build error

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -4,7 +4,6 @@
   "license": "MIT",
   "scripts": {
     "start": "tsx src/index.ts",
-    "build": "pkgroll",
     "lint": "eslint . --max-warnings=0 --ignore-path ../../.eslintignore",
     "lint:fix": "eslint src --fix"
   },
@@ -24,7 +23,6 @@
     "dotenv": "^16.4.5",
     "drizzle-kit": "^0.23.0",
     "eslint": "^8.0.0",
-    "pkgroll": "^2.0.2",
     "tsx": "^4.7.3",
     "typescript": "^5.4.5"
   }


### PR DESCRIPTION
This PR fixes the backend build error by removing unused `build` command and `pkgroll` dev dependency