### PR TITLE
Replace Nethermind RPC with Blast

### DIFF
--- a/packages/frontend/src/components/Web3Provider/index.tsx
+++ b/packages/frontend/src/components/Web3Provider/index.tsx
@@ -2,7 +2,7 @@ import { argent, braavos, StarknetConfig, starkscan, useInjectedConnectors, useN
 import { QueryClient } from '@tanstack/react-query'
 import { Provider as HooksProvider } from 'hooks'
 import { useMemo } from 'react'
-import { nethermindRpcProviders, SUPPORTED_STARKNET_NETWORKS } from 'src/constants/networks'
+import { blastRpcProviders, SUPPORTED_STARKNET_NETWORKS } from 'src/constants/networks'
 import { ArgentMobileConnector } from 'starknetkit/argentMobile'
 import { WebWalletConnector } from 'starknetkit/webwallet'
 
@@ -29,7 +29,7 @@ export function StarknetProvider({ children }: React.PropsWithChildren) {
       queryClient={queryClient}
       connectors={connectors}
       chains={SUPPORTED_STARKNET_NETWORKS}
-      provider={nethermindRpcProviders}
+      provider={blastRpcProviders}
       explorer={starkscan}
       autoConnect
     >
@@ -42,7 +42,7 @@ export function StarknetProvider({ children }: React.PropsWithChildren) {
 export function HooksSDKProvider({ children }: React.PropsWithChildren) {
   const { chain } = useNetwork()
 
-  const provider = useMemo(() => nethermindRpcProviders(chain) ?? undefined, [chain])
+  const provider = useMemo(() => blastRpcProviders(chain) ?? undefined, [chain])
 
   return (
     <HooksProvider provider={provider} queryClient={queryClient}>

--- a/packages/frontend/src/constants/networks.ts
+++ b/packages/frontend/src/constants/networks.ts
@@ -4,7 +4,6 @@ import { RpcProvider } from 'starknet'
 
 export const SUPPORTED_STARKNET_NETWORKS = [mainnet, goerli]
 
-
 const DEFAULT_NETWORK_NAME = process.env.REACT_APP_DEFAULT_NETWORK_NAME as string
 if (typeof DEFAULT_NETWORK_NAME === 'undefined') {
   throw new Error(`REACT_APP_DEFAULT_NETWORK_NAME must be a defined environment variable`)

--- a/packages/frontend/src/constants/networks.ts
+++ b/packages/frontend/src/constants/networks.ts
@@ -4,10 +4,6 @@ import { RpcProvider } from 'starknet'
 
 export const SUPPORTED_STARKNET_NETWORKS = [mainnet, goerli]
 
-const NETHERMIND_KEY = process.env.REACT_APP_NETHERMIND_KEY as string
-if (typeof NETHERMIND_KEY === 'undefined') {
-  throw new Error(`REACT_APP_NETHERMIND_KEY must be a defined environment variable`)
-}
 
 const DEFAULT_NETWORK_NAME = process.env.REACT_APP_DEFAULT_NETWORK_NAME as string
 if (typeof DEFAULT_NETWORK_NAME === 'undefined') {
@@ -16,16 +12,16 @@ if (typeof DEFAULT_NETWORK_NAME === 'undefined') {
   throw new Error(`REACT_APP_DEFAULT_NETWORK_NAME is invalid`)
 }
 
-export const nethermindRpcProviders: ChainProviderFactory = (chain: Chain) => {
+export const blastRpcProviders: ChainProviderFactory = (chain: Chain) => {
   switch (chain.id) {
     case goerli.id:
       return new RpcProvider({
-        nodeUrl: `https://rpc.nethermind.io/goerli-juno/?apikey=${NETHERMIND_KEY}`,
+        nodeUrl: `https://starknet-sepolia.public.blastapi.io`,
       })
 
     case mainnet.id:
       return new RpcProvider({
-        nodeUrl: `https://rpc.nethermind.io/mainnet-juno/?apikey=${NETHERMIND_KEY}`,
+        nodeUrl: `https://starknet-mainnet.public.blastapi.io`,
       })
 
     default:

--- a/packages/frontend/src/pages/Token/LaunchForm/Confirm/template.tsx
+++ b/packages/frontend/src/pages/Token/LaunchForm/Confirm/template.tsx
@@ -112,8 +112,8 @@ export default function LaunchTemplate({ liquidityPrice, teamAllocationPrice, pr
           loading
             ? 'Loading...'
             : hasEnoughQuoteTokenBalance
-              ? `Launch on ${amm}`
-              : `Insufficient ${quoteToken.symbol} balance`
+            ? `Launch on ${amm}`
+            : `Insufficient ${quoteToken.symbol} balance`
         }
         onNext={next}
         disableNext={loading || !hasEnoughQuoteTokenBalance}


### PR DESCRIPTION
Nethermind RPC is sunset, replacing with Blast API
- Replacing Nethermind URLs with Blast URLs
- Renaming nethermindRpcProviders to blastRpcProviders
- Fixing formatting issues that prevent deployment 